### PR TITLE
Add a required python package in the README.md

### DIFF
--- a/llama3_inference/README.md
+++ b/llama3_inference/README.md
@@ -10,7 +10,7 @@
 
 ### Required python packages
 
-    pip3 install torch, huggingface_hub, transformers, datasets, bitsandbytes, gradio, pypdf
+    pip3 install torch huggingface_hub transformers datasets bitsandbytes gradio pypdf accelerate
 
 A Gradio-based web UI is provided, and the default configuration allows access at 127.0.0.1:7860.
 


### PR DESCRIPTION
Thanks for sharing this great project! :)

Based on the error message, it seems we need to add `accelerate` to the required Python package list.

So, this minor PR update the Readme.md.

```
Traceback (most recent call last):
  File "/home/shson/go/src/github.com/cloud-barista/aicomp/llama3_inference/llama3_inference_basic.py", line 28, in <module>
    model = AutoModelForCausalLM.from_pretrained(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shson/go/src/github.com/cloud-barista/aicomp/llama3_inference/venv/lib/python3.12/site-packages/transformers/models/auto/auto_factory.py", line 564, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shson/go/src/github.com/cloud-barista/aicomp/llama3_inference/venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 3589, in from_pretrained
    raise ImportError(
ImportError: Using low_cpu_mem_usage=True or a device_map requires Accelerate: pip install 'accelerate>=0.26.0'
```

