### PR TITLE
add Feature/dynamo capture

### DIFF
--- a/opt_prime/examples/pp_generation_llama.py
+++ b/opt_prime/examples/pp_generation_llama.py
@@ -106,6 +106,8 @@ def parse_args():
         help="Use KVCacheManager as external backend for CachedSDPA "
              "(default: CachedSDPA internal cache)"
     )
+    parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                        help='Use torch.export.export() instead of HFTracer/symbolic_trace')
     return parser.parse_args()
 
 
@@ -159,6 +161,7 @@ def main():
         dtype=dtype,
         use_kv_cache=True,     # must be True for CachedSDPA injection
         use_kv_manager=args.use_kv_manager,
+        dynamo_capture=args.dynamo_capture,
     )
     engine.eval()
 

--- a/opt_prime/examples/pp_inference_llama.py
+++ b/opt_prime/examples/pp_inference_llama.py
@@ -146,6 +146,8 @@ def parse_args():
         help="Use KVCacheManager as external backend for CachedSDPA "
              "(implies --use-kv-cache)"
     )
+    parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                        help='Use torch.export.export() instead of HFTracer/symbolic_trace')
     return parser.parse_args()
 
 
@@ -230,6 +232,7 @@ def main():
         use_kv_cache=args.use_kv_cache,
         serving_mode=args.serving_mode,
         use_kv_manager=args.use_kv_manager,
+        dynamo_capture=args.dynamo_capture,
     )
 
     # Set to evaluation mode

--- a/opt_prime/examples/pp_train_bert.py
+++ b/opt_prime/examples/pp_train_bert.py
@@ -15,6 +15,7 @@ import sys
 import math
 import time
 
+import argparse
 from transformers import BertTokenizer, BertLMHeadModel, BertConfig
 from datasets import load_dataset
 from torch.utils.data import DataLoader
@@ -52,7 +53,12 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True)
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()

--- a/opt_prime/examples/pp_train_electra.py
+++ b/opt_prime/examples/pp_train_electra.py
@@ -15,6 +15,7 @@ import sys
 import math
 import time
 
+import argparse
 from transformers import AutoTokenizer, ElectraForCausalLM, ElectraConfig
 from datasets import load_dataset
 from torch.utils.data import DataLoader
@@ -53,8 +54,13 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 

--- a/opt_prime/examples/pp_train_gpt-neo.py
+++ b/opt_prime/examples/pp_train_gpt-neo.py
@@ -15,6 +15,7 @@ import sys
 import math
 import time
 
+import argparse
 from transformers import GPT2Tokenizer, GPTNeoForCausalLM, GPTNeoConfig
 from datasets import load_dataset
 from torch.utils.data import DataLoader
@@ -52,7 +53,12 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True)
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()

--- a/opt_prime/examples/pp_train_gpt2-medium.py
+++ b/opt_prime/examples/pp_train_gpt2-medium.py
@@ -14,6 +14,7 @@ import os
 import sys
 import math
 import time
+import argparse
 
 from transformers import GPT2Tokenizer, GPT2LMHeadModel, GPT2Config
 from datasets import load_dataset
@@ -52,7 +53,12 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True)
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()

--- a/opt_prime/examples/pp_train_gpt2-xl-flops.py
+++ b/opt_prime/examples/pp_train_gpt2-xl-flops.py
@@ -14,6 +14,7 @@ import os
 import sys
 import math
 import time
+import argparse
 
 from transformers import GPT2Tokenizer, GPT2LMHeadModel, GPT2Config
 from datasets import load_dataset
@@ -72,7 +73,12 @@ if int(os.environ["RANK"]) == 0:
     macs, params = get_model_complexity_info(model, (1, 1024), as_strings=True, input_constructor=partial(gpt_input_constructor, tokenizer=tokenizer), print_per_layer_stat=True, verbose=True)
     print('>>>>>>> # of Operations:', macs, ', # of Parameters', params)
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True)
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()

--- a/opt_prime/examples/pp_train_gpt2-xl.py
+++ b/opt_prime/examples/pp_train_gpt2-xl.py
@@ -14,6 +14,7 @@ import os
 import sys
 import math
 import time
+import argparse
 
 from transformers import GPT2Tokenizer, GPT2LMHeadModel, GPT2Config
 from datasets import load_dataset
@@ -52,7 +53,12 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True)
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()

--- a/opt_prime/examples/pp_train_gpt2.py
+++ b/opt_prime/examples/pp_train_gpt2.py
@@ -15,6 +15,7 @@ import sys
 import math
 import time
 
+import argparse
 from transformers import GPT2Tokenizer, GPT2LMHeadModel, GPT2Config
 from datasets import load_dataset
 from torch.utils.data import DataLoader
@@ -52,7 +53,12 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True)
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, dynamo_capture=args.dynamo_capture)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, dp_size=2)
 print(f" rank={optimus_p.get_rank()} ...")
 

--- a/opt_prime/examples/pp_train_gpt2_ckpt_save.py
+++ b/opt_prime/examples/pp_train_gpt2_ckpt_save.py
@@ -14,6 +14,7 @@ import os
 import sys
 import math
 import time
+import argparse
 
 from transformers import GPT2Tokenizer, GPT2LMHeadModel, GPT2Config
 from datasets import load_dataset
@@ -52,7 +53,12 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, checkpoint=True, ckpt_dir_postfix="gpt2")
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, checkpoint=True, ckpt_dir_postfix="gpt2", dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()

--- a/opt_prime/examples/pp_train_gptj.py
+++ b/opt_prime/examples/pp_train_gptj.py
@@ -15,6 +15,7 @@ import sys
 import math
 import time
 
+import argparse
 from transformers import GPT2Tokenizer, GPTJForCausalLM, GPTJConfig
 from datasets import load_dataset
 from torch.utils.data import DataLoader
@@ -53,8 +54,13 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 

--- a/opt_prime/examples/pp_train_llama-small.py
+++ b/opt_prime/examples/pp_train_llama-small.py
@@ -26,6 +26,8 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 
+import argparse
+
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
 from opt_prime.IR import IR_Anal
@@ -38,8 +40,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -89,7 +96,7 @@ if int(os.environ["RANK"]) == 0:
     print(f"num of mbatch: {num_mb}")
 
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL, dynamo_capture=args.dynamo_capture)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
 print(f" rank={optimus_p.get_rank()} ...")
 

--- a/opt_prime/examples/pp_train_llama.py
+++ b/opt_prime/examples/pp_train_llama.py
@@ -26,6 +26,8 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 
+import argparse
+
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
 from opt_prime.IR import IR_Anal
@@ -36,8 +38,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -85,7 +92,7 @@ if int(os.environ["RANK"]) == 0:
     print(f"num of mbatch: {num_mb}")
 
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, dp_size=8, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, dp_size=8, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()

--- a/opt_prime/examples/pp_train_llama2.py
+++ b/opt_prime/examples/pp_train_llama2.py
@@ -26,6 +26,8 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 
+import argparse
+
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
 from opt_prime.IR import IR_Anal
@@ -38,8 +40,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -85,7 +92,7 @@ if int(os.environ["RANK"]) == 0:
 
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()
@@ -127,7 +134,7 @@ def train():
 
         #optimus_p.run(data, labels)
         #optimus_p.run(data, labels, mode="gpipe")
-        with autocast(device_type='cuda', dtype=torch.bfloat16):    
+        with autocast(device_type='cuda', dtype=torch.bfloat16):
             optimus_p.run(data, labels, mode="1f1b")
 
         if optimus_p.is_last_stage():

--- a/opt_prime/examples/pp_train_llama3.py
+++ b/opt_prime/examples/pp_train_llama3.py
@@ -26,6 +26,8 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 
+import argparse
+
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
 from opt_prime.IR import IR_Anal
@@ -64,8 +66,13 @@ if int(os.environ["RANK"]) == 0:
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -102,7 +109,7 @@ for i in range(local_world_size):
         if int(os.environ["RANK"]) == 0:
             print('Total parameters in model: {:,}'.format(get_total_params(model)))
 
-        optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.PARALLEL) ## IR_Anal.PARALLEL 
+        optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.PARALLEL, dynamo_capture=args.dynamo_capture) ## IR_Anal.PARALLEL
         print(f" rank={optimus_p.get_rank()} ...")
 
     print(f"..[local_rank:{local_rank}, i:{i}] Before barrier()...")

--- a/opt_prime/examples/pp_train_llama4.py
+++ b/opt_prime/examples/pp_train_llama4.py
@@ -26,6 +26,7 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 
+import argparse
 import transformers
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
@@ -38,8 +39,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -103,7 +109,7 @@ if int(os.environ["RANK"]) == 0:
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()

--- a/opt_prime/examples/pp_train_llama4_ckpt_load.py
+++ b/opt_prime/examples/pp_train_llama4_ckpt_load.py
@@ -28,6 +28,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 
 import transformers
+import argparse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
@@ -39,8 +40,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:

--- a/opt_prime/examples/pp_train_llama4_ckpt_save.py
+++ b/opt_prime/examples/pp_train_llama4_ckpt_save.py
@@ -27,6 +27,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 
 import transformers
+import argparse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
@@ -38,8 +39,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:

--- a/opt_prime/examples/pp_train_llama5.py
+++ b/opt_prime/examples/pp_train_llama5.py
@@ -27,6 +27,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 
 import transformers
+import argparse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
@@ -50,8 +51,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -111,7 +117,7 @@ if int(os.environ["RANK"]) == 0:
 
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=4, tp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=2, dp_size=4, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=2, tp_size=2, dp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=2, tp_size=2, dp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL, dynamo_capture=args.dynamo_capture)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=2, tp_size=4, dp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=4, tp_size=2, dp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, tp_size=4, dp_size=4, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)

--- a/opt_prime/examples/pp_train_llama5_3d_valid.py
+++ b/opt_prime/examples/pp_train_llama5_3d_valid.py
@@ -27,6 +27,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 
 import transformers
+import argparse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
@@ -37,8 +38,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -97,7 +103,7 @@ if int(os.environ["RANK"]) == 0:
     print(f"num of mbatch: {num_mb}")
 
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=2, tp_size=2, dp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL, prt_shape=True)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=2, tp_size=2, dp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL, prt_shape=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 

--- a/opt_prime/examples/pp_train_llama6.py
+++ b/opt_prime/examples/pp_train_llama6.py
@@ -27,6 +27,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 
 import transformers
+import argparse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
@@ -50,8 +51,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -126,7 +132,7 @@ if int(os.environ["RANK"]) == 0:
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=2, tp_size=8, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, tp_size=8, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, tp_size=2, dp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, tp_size=2, dp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL, dynamo_capture=args.dynamo_capture)
 
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, pp_size=4, tp_size=4, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
 print(f" rank={optimus_p.get_rank()} ...")

--- a/opt_prime/examples/pp_train_llama6_3type.py
+++ b/opt_prime/examples/pp_train_llama6_3type.py
@@ -27,6 +27,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 
 import transformers
+import argparse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
@@ -38,8 +39,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:

--- a/opt_prime/examples/pp_train_llama7.py
+++ b/opt_prime/examples/pp_train_llama7.py
@@ -27,6 +27,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 
 import transformers
+import argparse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
@@ -78,8 +79,13 @@ if int(os.environ["RANK"]) == 0:
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -131,7 +137,7 @@ for i in range(local_world_size):
             print('Total parameters in model: {:,}'.format(get_total_params(model)))
 
         #optimus_p = Optimus_p(model, num_mb, use_gpu=True, tp_size=2, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.PARALLEL) ## IR_Anal.PARALLEL
-        optimus_p = Optimus_p(model, num_mb, use_gpu=True, tp_size=2, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.PARALLEL, pre_barrier=group_gloo) ## IR_Anal.PARALLEL
+        optimus_p = Optimus_p(model, num_mb, use_gpu=True, tp_size=2, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.PARALLEL, pre_barrier=group_gloo, dynamo_capture=args.dynamo_capture) ## IR_Anal.PARALLEL
         #optimus_p = Optimus_p(model, num_mb, use_gpu=True, dp_size=2, activation_ckpt=False, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.PARALLEL, pre_barrier=group_gloo) ## IR_Anal.PARALLEL
         print(f" rank={optimus_p.get_rank()} ...")
 

--- a/opt_prime/examples/pp_train_llama8-flops.py
+++ b/opt_prime/examples/pp_train_llama8-flops.py
@@ -27,6 +27,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 
 import transformers
+import argparse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
@@ -41,8 +42,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:

--- a/opt_prime/examples/pp_train_llama8-small.py
+++ b/opt_prime/examples/pp_train_llama8-small.py
@@ -27,6 +27,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 
 import transformers
+import argparse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
@@ -40,8 +41,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:

--- a/opt_prime/examples/pp_train_llama_autocast.py
+++ b/opt_prime/examples/pp_train_llama_autocast.py
@@ -26,6 +26,7 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 
+import argparse
 from torch.amp import autocast
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
@@ -38,8 +39,13 @@ logging.basicConfig(level=logging.ERROR)
 #
 # This program needs 'access token' for Llama. First, obtain your access token for Llama !!!
 #
-if len(sys.argv) > 1:
-    os.environ['LLAMA_ACCESS_TOKEN'] = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('token', nargs='?', default=None, help='LLaMA access token')
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+if args.token:
+    os.environ['LLAMA_ACCESS_TOKEN'] = args.token
 
 access_token = os.getenv('LLAMA_ACCESS_TOKEN')
 if access_token is None:
@@ -86,7 +92,7 @@ if int(os.environ["RANK"]) == 0:
     print(f"number of mbatch: {num_mb}")
 
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL, dynamo_capture=args.dynamo_capture)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
 print(f" rank={optimus_p.get_rank()} ...")
 

--- a/opt_prime/examples/pp_train_opt.py
+++ b/opt_prime/examples/pp_train_opt.py
@@ -14,6 +14,7 @@ import os
 import sys
 import math
 import time
+import argparse
 
 from transformers import AutoTokenizer, OPTForCausalLM, OPTConfig
 from datasets import load_dataset
@@ -54,8 +55,13 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 

--- a/opt_prime/examples/pp_train_opt2.py
+++ b/opt_prime/examples/pp_train_opt2.py
@@ -14,6 +14,7 @@ import os
 import sys
 import math
 import time
+import argparse
 
 from transformers import AutoTokenizer, OPTForCausalLM, OPTConfig
 from datasets import load_dataset
@@ -53,9 +54,14 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=False, ir_analyze=IR_Anal.SEQUENTIAL)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()

--- a/opt_prime/examples/pp_train_qwen_moe.py
+++ b/opt_prime/examples/pp_train_qwen_moe.py
@@ -1,6 +1,12 @@
 #
 # Copyright (c) 2025-present, ETRI, All rights reserved.
 #
+# Usage: torchrun --nproc_per_node=<#_of_GPUs_per_node> --nnodes=<#_of_nodes> --node_rank=<current_node_rank>
+#                 --master_addr=<IP_of_rank_0> --master_port=29500 pp_train_qwen_moe.py
+#
+# *** This program was tested with torch 2.5.0 and transformers 4.46.2.
+#     The version of transformers used must be consistent across all machines used for testing ***
+#
 
 
 import torch
@@ -14,26 +20,60 @@ import os
 import sys
 import math
 import time
-import argparse
+from packaging import version
 
-from transformers import GPT2Tokenizer, GPT2LMHeadModel, GPT2Config
+from transformers import AutoTokenizer, AutoModelForCausalLM
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 
+import transformers
+import argparse
+
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from opt_prime.opti_pri import Optimus_p
+from opt_prime.IR import IR_Anal
 
 logging.basicConfig(level=logging.ERROR)
 
 
-tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=True,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+
+#
+# This program needs torch version 2.3.1 or higher !!!
+#
+required_version = "2.3.1"
+current_version = torch.__version__
+
+if version.parse(current_version) >= version.parse(required_version):
+    print(f"[rank:{int(os.environ['RANK'])}] torch version 2.3.1 or higher --> OK")
+else:
+    print(f"[rank:{int(os.environ['RANK'])}] current torch version is {current_version}.")
+    raise ValueError('This program needs torch version 2.3.1 or higher.')
+
+#
+# This program needs transformers version 4.46.2 or higher !!!
+#
+required_tf_version = "4.46.2"
+current_tf_version = transformers.__version__
+
+if version.parse(current_tf_version) >= version.parse(required_tf_version):
+    print(f"[rank:{int(os.environ['RANK'])}] transformers version 4.46.2 or higher --> OK")
+else:
+    print(f"[rank:{int(os.environ['RANK'])}] current transformers version is {current_tf_version}.")
+    raise ValueError('This program needs transformers version 4.46.2 or higher.')
+
+
+model_name = "Qwen/Qwen1.5-MoE-A2.7B"
+
+tokenizer = AutoTokenizer.from_pretrained(model_name)
 tokenizer.pad_token = tokenizer.eos_token
 tokenizer.pad_token_id = tokenizer.eos_token_id
 
-config = GPT2Config(use_cache=False)
-model = GPT2LMHeadModel(config)
-model = model.from_pretrained("gpt2") # TODO
-
+model = AutoModelForCausalLM.from_pretrained(model_name, use_cache=False)
 
 def get_total_params(module: torch.nn.Module):
     total_params = 0
@@ -54,31 +94,24 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--dynamo-capture', action='store_true', default=False,
-                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
-args = parser.parse_args()
-
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, checkpoint=True, ckpt_dir_postfix="gpt2", dynamo_capture=args.dynamo_capture)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 optimus_p.train()
-#optimus_p.optimizer = torch.optim.SGD(optimus_p.parameters(), lr=5.0)
-optimus_p.optimizer = torch.optim.Adam(optimus_p.parameters(), lr=3e-5)
+
+optimus_p.optimizer = torch.optim.Adam(optimus_p.parameters(), lr=3e-5, foreach=False)
 scheduler = torch.optim.lr_scheduler.StepLR(optimus_p.optimizer, 1.0, gamma=0.95)
 
 datasets = load_dataset("squad").data["train"]["context"]
 datasets = [str(record) for record in datasets if len(str(record)) < 500]
-dataloader = DataLoader(datasets, batch_size=batch_size, num_workers=4)
+dataloader = optimus_p.prepare_dataloader(datasets, batch_size)
 data_size=len(dataloader.dataset)
 print(f"data_size={data_size}")
 nbatches = len(dataloader)
 print(f"nbatches={nbatches}")
 
 
-#epochs = 3 # The number of epochs
-epochs = 2 # The number of epochs
-#epochs = 1 # The number of epochs
+epochs = 1 # The number of epochs
 
 def train():
 
@@ -86,6 +119,7 @@ def train():
 
     total_loss = 0
     start_time = time.time()
+
 
     for i, batch in enumerate(dataloader):
 
@@ -100,18 +134,15 @@ def train():
 
         optimus_p.optimizer.zero_grad()
 
-        #optimus_p.run(data, labels)
-        #optimus_p.run(data, labels, mode="gpipe")
         optimus_p.run(data, labels, mode="1f1b")
 
         if optimus_p.is_last_stage():
-            loss = optimus_p.get_loss() 
+            loss = optimus_p.get_loss()
         else:
             loss = None
 
-        torch.nn.utils.clip_grad_norm_(optimus_p.parameters(), 0.5)
-        optimus_p.optimizer.step()
 
+        optimus_p.optimizer.step()
 
         if optimus_p.is_last_stage():
             loss = sum(loss) / optimus_p.num_mb
@@ -123,27 +154,17 @@ def train():
                 print('| epoch {:3d} | {:5d}/{:5d} batches | '
                     'lr {:02.2f} | ms/batch {:5.2f} | '
                     'loss {:5.2f} | ppl {:8.2f}'.format(
-                        epoch+1, i, nbatches, scheduler.get_lr()[0],
+                        epoch, i, nbatches, scheduler.get_lr()[0],
                         elapsed * 1000 / log_interval,
                         cur_loss, math.exp(cur_loss)))
 
                 total_loss = 0
                 start_time = time.time()
 
-    optimus_p.save_ckpt(i, epoch)
-
-
 if optimus_p.get_rank() == 0:
     tick = time.time()
 
-loaded_ckpt = False
-
 for epoch in range(1, epochs + 1):
-#for epoch in range(2, epochs + 1):
-    if not loaded_ckpt:
-        optimus_p.load_ckpt(322, epoch)
-        loaded_ckpt = True
-
     epoch_start_time = time.time()
     train()
     scheduler.step()
@@ -154,5 +175,14 @@ if optimus_p.get_rank() == 0:
 
     print('Time elapsed: %.3f sec ' % (elapsed_time))
 
-print(f"[rank:{optimus_p.get_rank()}, run completed ...")
+if dist.is_initialized():
+    try:
+        dist.barrier()
+        print(f"[rank:{optimus_p.get_rank()} >> barrier ...")
+        torch.cuda.synchronize()
+        print(f"[rank:{optimus_p.get_rank()} >> synchronize...")
+        dist.destroy_process_group()
+    except Exception as e:
+        print(f"Cleanp on rank {optimus_p.get_rank()}: {e}")
 
+print(f"[rank:{optimus_p.get_rank()}, run completed ...")

--- a/opt_prime/examples/pp_train_synthetic.py
+++ b/opt_prime/examples/pp_train_synthetic.py
@@ -14,6 +14,7 @@ import os
 import sys
 import math
 import time
+import argparse
 
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
@@ -89,7 +90,12 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True)
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, dynamo_capture=args.dynamo_capture)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, dp_size=2, preserve_output=True)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, dp_size=2)
 print(f" rank={optimus_p.get_rank()} ...")

--- a/opt_prime/examples/pp_train_synthetic2.py
+++ b/opt_prime/examples/pp_train_synthetic2.py
@@ -18,6 +18,7 @@ import os
 import sys
 import math
 import time
+import argparse
 
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))

--- a/opt_prime/examples/pp_train_vit.py
+++ b/opt_prime/examples/pp_train_vit.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025-present, ETRI, All rights reserved.
 #
 # Usage: torchrun --nproc_per_node=<#_of_GPUs_per_node> --nnodes=<#_of_nodes> --node_rank=<current_node_rank> 
-#                 --master_addr=<IP_of_rank_0> --master_port=29500 pp_train_vit.py <llama_access_token>
+#                 --master_addr=<IP_of_rank_0> --master_port=29500 pp_train_vit.py 
 #
 # *** This program was tested with torch 2.5.0 and transformers 4.46.2.
 #     The version of transformers used must be consistent across all machines used for testing ***
@@ -21,6 +21,7 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader
 from transformers import ViTForImageClassification
 from transformers import ViTImageProcessor
+import argparse
 from torchvision.transforms import Compose, Normalize, RandomHorizontalFlip, RandomResizedCrop, Resize, ToTensor
 
 
@@ -85,7 +86,12 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
-optimus_p = Optimus_p(model, num_mb, use_gpu=True)
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, dynamo_capture=args.dynamo_capture)
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, swap_model_in_optstep=True, ir_analyze=IR_Anal.SEQUENTIAL)
 print(f" rank={optimus_p.get_rank()} ...")
 

--- a/opt_prime/examples/pp_train_whisper.py
+++ b/opt_prime/examples/pp_train_whisper.py
@@ -15,6 +15,7 @@ import sys
 import math
 import time
 
+import argparse
 from transformers import AutoTokenizer, WhisperForCausalLM, WhisperConfig
 from datasets import load_dataset
 from torch.utils.data import DataLoader
@@ -52,8 +53,13 @@ if int(os.environ["RANK"]) == 0:
     print(f"batch size: {batch_size}")
     print(f"num of mbatch: {num_mb}")
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                    help='Use TorchDynamo capture (torch.export) instead of HFTracer')
+args = parser.parse_args()
+
 #optimus_p = Optimus_p(model, num_mb, use_gpu=True)
-optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True)
+optimus_p = Optimus_p(model, num_mb, use_gpu=True, activation_ckpt=True, force_free_mem=True, display_mem=True, swap_opt_in_fwdbwd=True, dynamo_capture=args.dynamo_capture)
 print(f" rank={optimus_p.get_rank()} ...")
 
 

--- a/opt_prime/examples/serving_vs_batch_demo.py
+++ b/opt_prime/examples/serving_vs_batch_demo.py
@@ -73,6 +73,8 @@ def parse_args():
         choices=["float32", "float16", "bfloat16"],
         help="Data type for inference"
     )
+    parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                        help='Use torch.export.export() instead of HFTracer/symbolic_trace')
     return parser.parse_args()
 
 
@@ -238,6 +240,7 @@ def main():
         dtype=dtype,
         use_kv_cache=True,
         serving_mode=False,  # batch mode
+        dynamo_capture=args.dynamo_capture,
     )
     engine_batch.eval()
 
@@ -266,6 +269,7 @@ def main():
         dtype=dtype,
         use_kv_cache=True,
         serving_mode=True,  # serving mode
+        dynamo_capture=args.dynamo_capture,
     )
     engine_serving.eval()
 

--- a/opt_prime/examples/single_gpu_inference_llama.py
+++ b/opt_prime/examples/single_gpu_inference_llama.py
@@ -99,6 +99,8 @@ def parse_args():
         choices=["float32", "float16", "bfloat16"],
         help="Data type for inference"
     )
+    parser.add_argument('--dynamo-capture', action='store_true', default=False,
+                        help='Use torch.export.export() instead of HFTracer/symbolic_trace')
     return parser.parse_args()
 
 
@@ -155,6 +157,7 @@ def main():
         use_kv_cache=args.use_kv_cache,
         serving_mode=args.serving_mode,
         use_kv_manager=args.use_kv_manager,
+        dynamo_capture=args.dynamo_capture,
     )
     engine.eval()
 

--- a/opt_prime/opt_prime/IR.py
+++ b/opt_prime/opt_prime/IR.py
@@ -327,17 +327,46 @@ def build_module_graph_from_export(exported_program, original_model, input_names
     param_buffer_nodes = set()   # lifted params / buffers
     user_input_nodes = []        # actual user inputs (input_ids, ...)
 
-    # Build name→FQN map for params and buffers
+    # Build name→FQN map for params, buffers, and lifted tensor constants
     param_names = set()
     buffer_names = set()
+    lifted_constant_names = set()
     if hasattr(sig, 'inputs_to_parameters'):
         param_names = set(sig.inputs_to_parameters.keys())
     if hasattr(sig, 'inputs_to_buffers'):
         buffer_names = set(sig.inputs_to_buffers.keys())
+    if hasattr(sig, 'inputs_to_lifted_tensor_constants') and sig.inputs_to_lifted_tensor_constants:
+        lifted_constant_names = set(sig.inputs_to_lifted_tensor_constants.keys())
+        if int(os.environ.get("RANK", "0")) == 0:
+            print(f">> [IR] Found {len(lifted_constant_names)} lifted tensor constant(s) "
+                  f"(e.g. local attention masks)")
+        # Register lifted tensor constants as buffers on original_model
+        # so that get_attr can find them at runtime
+        for placeholder_name, fqn in sig.inputs_to_lifted_tensor_constants.items():
+            tensor_val = None
+            if hasattr(exported_program, 'constants') and fqn in exported_program.constants:
+                tensor_val = exported_program.constants[fqn]
+            elif hasattr(flat_gm, fqn.replace('.', '_')):
+                tensor_val = getattr(flat_gm, fqn.replace('.', '_'))
+            if tensor_val is not None:
+                # Walk/create the submodule path and register as buffer
+                parts = fqn.split('.')
+                parent = original_model
+                for part in parts[:-1]:
+                    if hasattr(parent, part):
+                        parent = getattr(parent, part)
+                    else:
+                        # Create intermediate Module if needed
+                        sub = torch.nn.Module()
+                        parent.add_module(part, sub)
+                        parent = sub
+                # Skip if attribute already exists (e.g. GPT-J embed_positions)
+                if not hasattr(parent, parts[-1]):
+                    parent.register_buffer(parts[-1], tensor_val, persistent=False)
 
     for node in flat_graph.nodes:
         if node.op == 'placeholder':
-            if node.name in param_names or node.name in buffer_names:
+            if node.name in param_names or node.name in buffer_names or node.name in lifted_constant_names:
                 param_buffer_nodes.add(node)
             else:
                 user_input_nodes.append(node)
@@ -490,12 +519,14 @@ def build_module_graph_from_export(exported_program, original_model, input_names
         if param_node in value_map:
             return value_map[param_node]
 
-        # Find the FQN for this param/buffer
+        # Find the FQN for this param/buffer/lifted constant
         fqn = None
         if hasattr(sig, 'inputs_to_parameters') and param_node.name in sig.inputs_to_parameters:
             fqn = sig.inputs_to_parameters[param_node.name]
         elif hasattr(sig, 'inputs_to_buffers') and param_node.name in sig.inputs_to_buffers:
             fqn = sig.inputs_to_buffers[param_node.name]
+        elif hasattr(sig, 'inputs_to_lifted_tensor_constants') and param_node.name in sig.inputs_to_lifted_tensor_constants:
+            fqn = sig.inputs_to_lifted_tensor_constants[param_node.name]
 
         if fqn:
             if fqn not in created_getattrs:

--- a/opt_prime/opt_prime/IR.py
+++ b/opt_prime/opt_prime/IR.py
@@ -40,8 +40,815 @@ import logging
 import os
 import gc
 from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+import operator
 
 from transformers.utils.fx import _SUPPORTED_MODELS
+
+
+# Check torch.export availability (requires PyTorch >= 2.4)
+_TORCH_EXPORT_AVAILABLE = (
+    hasattr(torch, 'export')
+    and hasattr(torch.export, 'export')
+)
+
+
+def _inline_subgraph_into_graph(call_node, submod, submod_attr_node, env,
+                                new_graph, grad_enabled=True):
+    """Inline a synthetic subgraph (from @torch.no_grad() etc.) into the main graph.
+
+    Args:
+        call_node: The call_function node (wrap_with_set_grad_enabled) to replace
+        submod: The synthetic fx.GraphModule containing the actual ATen ops
+        submod_attr_node: The get_attr node that loaded the submod
+        env: old_node -> new_node mapping (updated in place)
+        new_graph: Target fx.Graph to add inlined nodes into
+        grad_enabled: The grad-enabled flag from wrap_with_set_grad_enabled.
+                      If False, detach outputs to prevent gradient flow back
+                      through the inlined ops (preserving @torch.no_grad() semantics).
+    """
+    sub_graph = submod.graph
+    sub_env = {}
+
+    # Extract real args (skip bool/int/float constants and the GraphModule ref)
+    real_args = []
+    for arg in call_node.args:
+        if isinstance(arg, (bool, int, float)):
+            continue
+        if isinstance(arg, fx.Node) and arg is submod_attr_node:
+            continue
+        if isinstance(arg, fx.Node):
+            val = env.get(arg)
+            if val is not None:
+                real_args.append(val)
+        else:
+            real_args.append(arg)
+
+    # Map subgraph placeholders to real args
+    sub_placeholders = [n for n in sub_graph.nodes if n.op == 'placeholder']
+    for i, ph in enumerate(sub_placeholders):
+        if i < len(real_args):
+            sub_env[ph] = real_args[i]
+
+    def _sub_remap(x):
+        if isinstance(x, fx.Node):
+            return sub_env[x]
+        return x
+
+    # Process subgraph ATen ops (skip placeholder and output)
+    for sub_node in sub_graph.nodes:
+        if sub_node.op == 'placeholder':
+            continue
+
+        if sub_node.op == 'output':
+            # Map subgraph output → env[call_node]
+            out_args = sub_node.args[0]
+            if isinstance(out_args, fx.Node):
+                env[call_node] = sub_env[out_args]
+            elif isinstance(out_args, (tuple, list)):
+                mapped = []
+                for a in out_args:
+                    if isinstance(a, fx.Node):
+                        mapped.append(sub_env[a])
+                    else:
+                        mapped.append(a)
+                env[call_node] = tuple(mapped) if len(mapped) > 1 else mapped[0]
+            else:
+                env[call_node] = out_args
+
+            # If the original region was @torch.no_grad() (grad_enabled=False),
+            # insert detach() on tensor outputs to prevent gradient flow back
+            # through the inlined ops during backward pass.
+            if not grad_enabled:
+                val = env[call_node]
+                if isinstance(val, fx.Node):
+                    det = new_graph.call_function(
+                        torch.ops.aten.detach.default, (val,))
+                    det.meta = dict(val.meta) if val.meta else {}
+                    env[call_node] = det
+                elif isinstance(val, tuple):
+                    detached = []
+                    for v in val:
+                        if isinstance(v, fx.Node):
+                            det = new_graph.call_function(
+                                torch.ops.aten.detach.default, (v,))
+                            det.meta = dict(v.meta) if v.meta else {}
+                            detached.append(det)
+                        else:
+                            detached.append(v)
+                    env[call_node] = tuple(detached)
+            continue
+
+        new_args = fx.map_arg(sub_node.args, _sub_remap)
+        new_kwargs = fx.map_arg(sub_node.kwargs, _sub_remap)
+
+        if sub_node.op == 'call_function':
+            new_node = new_graph.call_function(sub_node.target, new_args, new_kwargs)
+            new_node.meta = dict(sub_node.meta) if sub_node.meta else {}
+            sub_env[sub_node] = new_node
+        elif sub_node.op == 'call_method':
+            new_node = new_graph.call_method(sub_node.target, new_args, new_kwargs)
+            new_node.meta = dict(sub_node.meta) if sub_node.meta else {}
+            sub_env[sub_node] = new_node
+        elif sub_node.op == 'get_attr':
+            # Target is relative to submod — prepend submod target for full path
+            full_target = f"{submod_attr_node.target}.{sub_node.target}"
+            new_node = new_graph.get_attr(full_target)
+            new_node.meta = dict(sub_node.meta) if sub_node.meta else {}
+            sub_env[sub_node] = new_node
+
+
+def _inline_higher_order_ops(flat_gm):
+    """Inline higher-order ops (from @torch.no_grad() etc.) into the main graph.
+
+    torch.export with strict=False creates synthetic subgraph modules (submod_0,
+    submod_1, ...) for @torch.no_grad() decorated functions. The main graph only
+    has get_attr + call_function[wrap_with_set_grad_enabled] for these. This
+    function replaces them with the actual ATen ops from the subgraph, so the
+    downstream module-graph reconstruction never sees synthetic GraphModules.
+
+    Args:
+        flat_gm: The GraphModule from ExportedProgram
+
+    Returns:
+        A new GraphModule with higher-order ops inlined (or flat_gm unchanged
+        if there are no higher-order ops)
+    """
+    old_graph = flat_gm.graph
+
+    # Step 1: Detect synthetic GraphModule attributes (from @torch.no_grad() etc.)
+    synthetic_modules = {}  # node -> fx.GraphModule
+    for node in old_graph.nodes:
+        if node.op == 'get_attr':
+            try:
+                obj = flat_gm
+                for p in node.target.split('.'):
+                    obj = getattr(obj, p)
+                if isinstance(obj, fx.GraphModule):
+                    synthetic_modules[node] = obj
+            except AttributeError:
+                pass
+
+    if not synthetic_modules:
+        return flat_gm  # No higher-order ops — return unchanged
+
+    # Detect grad_enabled flags by scanning call sites that use each synthetic module
+    synth_grad_flags = {}  # submod_attr_node -> grad_enabled
+    for node in old_graph.nodes:
+        if node.op == 'call_function':
+            for arg in node.all_input_nodes:
+                if arg in synthetic_modules:
+                    grad_flag = True
+                    for a in node.args:
+                        if isinstance(a, bool):
+                            grad_flag = a
+                            break
+                    synth_grad_flags[arg] = grad_flag
+
+    if int(os.environ.get("RANK", "0")) == 0:
+        print(f">> [IR] Inlining {len(synthetic_modules)} higher-order op(s) "
+              f"(from @torch.no_grad() etc.)")
+        for node, submod in synthetic_modules.items():
+            sub_nodes = sum(1 for n in submod.graph.nodes
+                           if n.op not in ('placeholder', 'output'))
+            grad_flag = synth_grad_flags.get(node, True)
+            detach_str = " → outputs detached (no-grad)" if not grad_flag else ""
+            print(f">>   {node.name} ({node.target}): {sub_nodes} ATen ops, "
+                  f"grad_enabled={grad_flag}{detach_str}")
+
+    # Step 2: Build new graph with inlined subgraphs
+    new_graph = fx.Graph()
+    env = {}  # old_node -> new_node (or tuple of new_nodes for multi-output)
+
+    for node in old_graph.nodes:
+        if node in synthetic_modules:
+            continue  # Skip get_attr for synthetic GraphModule
+
+        if node.op == 'placeholder':
+            new_node = new_graph.placeholder(node.name)
+            new_node.name = node.name
+            new_node.meta = dict(node.meta) if node.meta else {}
+            env[node] = new_node
+
+        elif node.op == 'output':
+            out_args = fx.map_arg(node.args[0], lambda n: env[n])
+            new_graph.output(out_args)
+
+        elif node.op == 'call_function':
+            # Check if this call uses a synthetic GraphModule arg
+            submod_node = None
+            for arg in node.all_input_nodes:
+                if arg in synthetic_modules:
+                    submod_node = arg
+                    break
+
+            if submod_node is not None:
+                # Extract grad_enabled flag from wrap_with_set_grad_enabled.
+                # The call looks like: wrap_with_set_grad_enabled(False, submod, ...)
+                # where the first bool arg is the grad-enabled flag.
+                grad_enabled = True
+                for arg in node.args:
+                    if isinstance(arg, bool):
+                        grad_enabled = arg
+                        break
+
+                # Inline the subgraph
+                _inline_subgraph_into_graph(
+                    node, synthetic_modules[submod_node], submod_node,
+                    env, new_graph, grad_enabled=grad_enabled
+                )
+            elif (node.target is operator.getitem
+                  and isinstance(node.args[0], fx.Node)
+                  and isinstance(env.get(node.args[0]), tuple)):
+                # Resolve getitem on multi-output inlined op directly
+                idx = node.args[1]
+                env[node] = env[node.args[0]][idx]
+            else:
+                # Normal call_function
+                new_args = fx.map_arg(node.args, lambda n: env[n])
+                new_kwargs = fx.map_arg(node.kwargs, lambda n: env[n])
+                new_node = new_graph.call_function(node.target, new_args, new_kwargs)
+                new_node.name = node.name
+                new_node.meta = dict(node.meta) if node.meta else {}
+                env[node] = new_node
+
+        elif node.op == 'get_attr':
+            new_node = new_graph.get_attr(node.target)
+            new_node.name = node.name
+            new_node.meta = dict(node.meta) if node.meta else {}
+            env[node] = new_node
+
+        elif node.op == 'call_method':
+            new_args = fx.map_arg(node.args, lambda n: env[n])
+            new_kwargs = fx.map_arg(node.kwargs, lambda n: env[n])
+            new_node = new_graph.call_method(node.target, new_args, new_kwargs)
+            new_node.name = node.name
+            new_node.meta = dict(node.meta) if node.meta else {}
+            env[node] = new_node
+
+    new_graph.lint()
+    return GraphModule(flat_gm, new_graph)
+
+
+def build_module_graph_from_export(exported_program, original_model, input_names=None):
+    """
+    Reconstruct a module-level FX graph from ExportedProgram using
+    nn_module_stack metadata, completely bypassing torch.export.unflatten().
+
+    Produces a flat graph with call_module nodes for leaf nn.Modules,
+    matching the format HFTracer would generate.
+
+    Args:
+        exported_program: Result of torch.export.export()
+        original_model: The original nn.Module (provides module hierarchy)
+        input_names: List of user input names (e.g., ['input_ids', 'position_ids'])
+
+    Returns:
+        GraphModule compatible with split_module() and existing split logic
+    """
+    flat_gm = exported_program.graph_module
+
+    # ── Pre-processing: Inline higher-order ops ──
+    # torch.export (strict=False) wraps @torch.no_grad() functions in synthetic
+    # subgraph modules (submod_0, submod_1, ...).  Inline them so the module-graph
+    # reconstruction never sees synthetic GraphModules.
+    flat_gm = _inline_higher_order_ops(flat_gm)
+
+    flat_graph = flat_gm.graph
+    sig = exported_program.graph_signature
+
+    # ── Step 1: Identify leaf modules (no children = leaf) ──
+    leaf_fqns = set()
+    for fqn, mod in original_model.named_modules():
+        if fqn and len(list(mod.children())) == 0:
+            leaf_fqns.add(fqn)
+
+    # ── Step 2: Classify placeholder nodes ──
+    param_buffer_nodes = set()   # lifted params / buffers
+    user_input_nodes = []        # actual user inputs (input_ids, ...)
+
+    # Build name→FQN map for params and buffers
+    param_names = set()
+    buffer_names = set()
+    if hasattr(sig, 'inputs_to_parameters'):
+        param_names = set(sig.inputs_to_parameters.keys())
+    if hasattr(sig, 'inputs_to_buffers'):
+        buffer_names = set(sig.inputs_to_buffers.keys())
+
+    for node in flat_graph.nodes:
+        if node.op == 'placeholder':
+            if node.name in param_names or node.name in buffer_names:
+                param_buffer_nodes.add(node)
+            else:
+                user_input_nodes.append(node)
+
+    # Map exported user‐input placeholder names → canonical names
+    # When kwargs are used with export(), placeholder names already match
+    # parameter names (e.g., "input_ids", "position_ids").
+    # When positional args are used, names may be mangled ("arg0_1", etc.)
+    # and need remapping via input_names.
+    canonical_names = {}
+    if input_names:
+        input_name_set = set(input_names)
+        # First: if placeholder name already matches an input name, use it
+        matched = set()
+        for node in user_input_nodes:
+            if node.name in input_name_set:
+                canonical_names[node.name] = node.name
+                matched.add(node.name)
+        # Then: for remaining unmatched, fall back to positional mapping
+        remaining_names = [n for n in input_names if n not in matched]
+        remaining_nodes = [n for n in user_input_nodes if n.name not in matched]
+        for i, node in enumerate(remaining_nodes):
+            if i < len(remaining_names):
+                canonical_names[node.name] = remaining_names[i]
+            else:
+                canonical_names[node.name] = node.name
+    else:
+        for node in user_input_nodes:
+            canonical_names[node.name] = node.name
+
+    # ── Step 3: Assign each node to its owning leaf module ──
+    def _get_owning_leaf(node):
+        stack = node.meta.get('nn_module_stack', {})
+        if not stack:
+            return None
+        # Walk from deepest to shallowest
+        for _key, (fqn, _cls) in reversed(list(stack.items())):
+            if fqn in leaf_fqns:
+                return fqn
+        return None
+
+    node_owner = {}  # node → fqn or None
+    for node in flat_graph.nodes:
+        if node.op in ('placeholder', 'output'):
+            node_owner[node] = None
+        else:
+            node_owner[node] = _get_owning_leaf(node)
+
+
+    # ── Step 4: Build execution regions ──
+    # Each region is either a "module" region (all nodes for one leaf module call)
+    # or an "inline" region (ops not inside any leaf module).
+    regions = []  # list of dicts: {'type': 'module'|'inline', 'fqn': str|None, 'nodes': [Node]}
+
+    current_region = None
+    for node in flat_graph.nodes:
+        if node.op in ('placeholder', 'output'):
+            continue
+        owner = node_owner[node]
+        if owner is not None:
+            # Module node
+            if current_region and current_region['type'] == 'module' and current_region['fqn'] == owner:
+                current_region['nodes'].append(node)
+            else:
+                current_region = {'type': 'module', 'fqn': owner, 'nodes': [node]}
+                regions.append(current_region)
+        else:
+            # Inline node
+            if current_region and current_region['type'] == 'inline':
+                current_region['nodes'].append(node)
+            else:
+                current_region = {'type': 'inline', 'fqn': None, 'nodes': [node]}
+                regions.append(current_region)
+
+    # ── Step 4b: Validate module regions for nn.Embedding subclasses ──
+    # When a subclass of nn.Embedding overrides forward() (e.g.
+    # OPTLearnedPositionalEmbedding), TorchDynamo may not attribute all
+    # internal ops to the leaf module.  For OPTLearnedPositionalEmbedding:
+    #   forward(attention_mask, ...):
+    #       position_ids = cumsum(attention_mask) ...  # position computation
+    #       return super().forward(position_ids + offset)  # aten.embedding
+    #
+    # TorchDynamo may classify cumsum/mul/sub/slice as belonging to the
+    # parent module (OPTDecoder), leaving only add_offset + aten.embedding
+    # in the embed_positions region.  The inline ops compute position_ids,
+    # and the call_module receives these pre-computed position_ids.  But
+    # the call_module runs the FULL overridden forward(), which expects
+    # attention_mask and internally recomputes cumsum → double-computation
+    # of position indices → out-of-bounds embedding access.
+    #
+    # Fix: for nn.Embedding SUBCLASSES that override forward(), always
+    # demote to inline.  Plain nn.Embedding (no override) is safe since
+    # its forward is just F.embedding → single aten.embedding op.
+    for region in regions:
+        if region['type'] != 'module':
+            continue
+        fqn = region['fqn']
+        try:
+            mod = original_model.get_submodule(fqn)
+        except (AttributeError, ValueError):
+            continue
+        if not isinstance(mod, nn.Embedding):
+            continue
+        # Plain nn.Embedding: forward is just F.embedding, safe as call_module
+        if type(mod) is nn.Embedding:
+            continue
+        # Subclass with overridden forward() — always demote to inline
+        if int(os.environ.get("RANK", "0")) == 0:
+            print(f">> [IR] DEMOTING nn.Embedding subclass region "
+                  f"'{fqn}' ({type(mod).__name__}): overridden forward() "
+                  f"may have ops split across inline/module boundaries")
+        region['type'] = 'inline'
+        region['fqn'] = None
+
+    # ── Step 5: Build new module-level graph ──
+    new_graph = fx.Graph()
+    value_map = {}   # old_node → new_node
+    used_names = set()
+    # Track get_attr nodes we already created (for buffers referenced by inline ops)
+    created_getattrs = {}  # buffer_fqn → new_node
+
+    def _make_name(base: str) -> str:
+        """Generate unique node name from a base string."""
+        name = base.replace('.', '_')
+        if name not in used_names:
+            used_names.add(name)
+            return name
+        i = 1
+        while f"{name}_{i}" in used_names:
+            i += 1
+        used_names.add(f"{name}_{i}")
+        return f"{name}_{i}"
+
+    def _remap(x):
+        """Remap a single arg from old graph to new graph."""
+        if isinstance(x, fx.Node):
+            if x in value_map:
+                return value_map[x]
+            # If it's a param/buffer placeholder not yet mapped, create get_attr
+            if x in param_buffer_nodes:
+                return _get_or_create_getattr(x)
+            raise KeyError(f"Unmapped node: {x.name} (op={x.op})")
+        return x
+
+    def _remap_all(args):
+        return fx.map_arg(args, _remap)
+
+    def _get_or_create_getattr(param_node):
+        """Create a get_attr node for a parameter/buffer placeholder."""
+        if param_node in value_map:
+            return value_map[param_node]
+
+        # Find the FQN for this param/buffer
+        fqn = None
+        if hasattr(sig, 'inputs_to_parameters') and param_node.name in sig.inputs_to_parameters:
+            fqn = sig.inputs_to_parameters[param_node.name]
+        elif hasattr(sig, 'inputs_to_buffers') and param_node.name in sig.inputs_to_buffers:
+            fqn = sig.inputs_to_buffers[param_node.name]
+
+        if fqn:
+            if fqn not in created_getattrs:
+                ga_name = _make_name(fqn)
+                ga_node = new_graph.get_attr(fqn)
+                ga_node.name = ga_name
+                created_getattrs[fqn] = ga_node
+            value_map[param_node] = created_getattrs[fqn]
+            return created_getattrs[fqn]
+        else:
+            # Unknown param/buffer — create placeholder as fallback
+            ph = new_graph.placeholder(param_node.name)
+            value_map[param_node] = ph
+            return ph
+
+    def _resolve_get_attr_target(target):
+        """Resolve a get_attr target to a valid FQN on original_model.
+
+        torch.export with strict=False may create synthetic submodules
+        (e.g. submod_0, submod_1) for @torch.no_grad() wrappers.
+        These exist on the export graph_module but not on original_model.
+        We resolve them by matching the actual tensor via data_ptr().
+        """
+        # Check if target is already valid on original_model
+        parts = target.split('.')
+        try:
+            obj = original_model
+            for p in parts:
+                obj = getattr(obj, p)
+            return target
+        except AttributeError:
+            pass
+
+        # Target is synthetic — resolve via flat_gm
+        try:
+            obj = flat_gm
+            for p in parts:
+                obj = getattr(obj, p)
+        except AttributeError:
+            return target  # can't resolve
+
+        if isinstance(obj, torch.Tensor):
+            # Match tensor by data_ptr to find real FQN
+            for name, param in original_model.named_parameters():
+                if param.data_ptr() == obj.data_ptr():
+                    return name
+            for name, buf in original_model.named_buffers():
+                if buf.data_ptr() == obj.data_ptr():
+                    return name
+        elif isinstance(obj, nn.Module):
+            # Match module by identity
+            for name, mod in original_model.named_modules():
+                if mod is obj:
+                    return name
+
+        return target  # fallback: return as-is
+
+    # 5a. Create user input placeholders with canonical names
+    for node in user_input_nodes:
+        cname = canonical_names.get(node.name, node.name)
+        new_ph = new_graph.placeholder(cname)
+        new_ph.name = _make_name(cname)
+        value_map[node] = new_ph
+
+    # ── Helper: determine if a node produces a tensor (not a scalar/int) ──
+    def _is_tensor_producer(n):
+        if n.op in ('call_module', 'placeholder', 'get_attr'):
+            return True
+        if n.op == 'call_function':
+            tgt = getattr(n.target, '__name__', str(n.target))
+            if 'sym_size' in tgt or 'sym_numel' in tgt:
+                return False
+            return True
+        return False
+
+    # Counter for tracking skipped nodes across all _emit_inline calls
+    _skipped_nodes_info = []  # list of (node_name, target, error)
+
+    # ── Helper: process a list of nodes as inline ATen ops ──
+    def _emit_inline(nodes_list):
+        """Copy ATen ops into new_graph, fixing device=cpu kwargs."""
+        region_set = set(nodes_list)
+
+        # Find an external TENSOR input for device inference
+        _device_ref = None
+        _need_dev = any(
+            n.op == 'call_function'
+            and isinstance(n.kwargs.get('device'), torch.device)
+            and str(n.kwargs['device']) == 'cpu'
+            for n in nodes_list
+        )
+        if _need_dev:
+            # Prefer call_module / placeholder (guaranteed tensors)
+            for n in nodes_list:
+                for arg in n.all_input_nodes:
+                    if arg not in region_set and arg not in param_buffer_nodes:
+                        if arg in value_map and arg.op in ('call_module', 'placeholder'):
+                            _device_ref = value_map[arg]
+                            break
+                if _device_ref:
+                    break
+            # Fallback: any tensor-producing external node
+            if _device_ref is None:
+                for n in nodes_list:
+                    for arg in n.all_input_nodes:
+                        if arg not in region_set and arg not in param_buffer_nodes:
+                            if arg in value_map and _is_tensor_producer(arg):
+                                _device_ref = value_map[arg]
+                                break
+                    if _device_ref:
+                        break
+            # Final fallback: when all inputs are SymInts (e.g., torch.arange
+            # computing position_ids from shape metadata), find any previously
+            # emitted placeholder or call_module in the graph.
+            if _device_ref is None:
+                for prev_node in new_graph.nodes:
+                    if prev_node.op in ('placeholder', 'call_module'):
+                        _device_ref = prev_node
+                        break
+
+        # Create device extraction node if needed
+        _dev_node = None
+        if _device_ref is not None:
+            _dev_node = new_graph.call_function(
+                getattr, args=(_device_ref, 'device')
+            )
+            _dev_node.name = _make_name('_inline_device')
+
+        for node in nodes_list:
+            try:
+                new_args = _remap_all(node.args)
+                new_kwargs = _remap_all(node.kwargs)
+            except KeyError as e:
+                tgt = getattr(node.target, '__name__', str(node.target))
+                _skipped_nodes_info.append((node.name, tgt, str(e)))
+                if int(os.environ.get("RANK", "0")) == 0:
+                    print(f">> [IR] _emit_inline SKIPPED node '{node.name}' "
+                          f"(target={tgt}): {e}")
+                continue
+
+            # Replace device=cpu with runtime device reference
+            if (_dev_node is not None
+                    and node.op == 'call_function'
+                    and isinstance(node.kwargs.get('device'), torch.device)
+                    and str(node.kwargs['device']) == 'cpu'):
+                new_kwargs = dict(new_kwargs)
+                new_kwargs['device'] = _dev_node
+
+            if node.op == 'call_function':
+                nn = _make_name(node.name)
+                target = node.target
+                # Replace aten.view / _unsafe_view with aten.reshape for
+                # non-contiguous tensors (after transpose in attention)
+                if (target is torch.ops.aten.view.default
+                        or target is torch.ops.aten._unsafe_view.default):
+                    target = torch.ops.aten.reshape.default
+                new_node = new_graph.call_function(target, new_args, new_kwargs)
+                new_node.name = nn
+                value_map[node] = new_node
+            elif node.op == 'call_method':
+                nn = _make_name(node.name)
+                new_node = new_graph.call_method(node.target, new_args, new_kwargs)
+                new_node.name = nn
+                value_map[node] = new_node
+            elif node.op == 'get_attr':
+                resolved = _resolve_get_attr_target(node.target)
+                nn = _make_name(resolved)
+                new_node = new_graph.get_attr(resolved)
+                new_node.name = nn
+                value_map[node] = new_node
+
+    # 5b. Process regions
+    for region in regions:
+        if region['type'] == 'module':
+            fqn = region['fqn']
+            nodes = region['nodes']
+            node_set = set(nodes)
+
+            # Find inputs: values from outside this region, excluding
+            # params/buffers AND non-tensor SymInt values (sym_size, etc.).
+            # SymInts represent shape metadata that will be recomputed at
+            # runtime from the actual tensors passed to the module.
+            inputs = []
+            seen_inputs = set()
+            for n in nodes:
+                for arg_node in n.all_input_nodes:
+                    if arg_node not in node_set and arg_node not in param_buffer_nodes:
+                        if id(arg_node) not in seen_inputs:
+                            seen_inputs.add(id(arg_node))
+                            if _is_tensor_producer(arg_node):
+                                inputs.append(arg_node)
+
+
+            # ── Signature check ──
+            # If the number of external inputs doesn't match the module's
+            # forward() required parameters, the call_module would fail
+            # (e.g., LlamaRotaryEmbedding.forward(x, position_ids) where
+            # x is only used for device/dtype — no ATen ops reference it).
+            #
+            # Strategy:
+            # 1. If exactly 1 input is missing, try to find a suitable
+            #    tensor from preceding nodes to use as a substitute.
+            #    This preserves the module's internal precision handling
+            #    (e.g., torch.autocast(enabled=False) in RoPE).
+            # 2. Otherwise, demote the region to inline ATen ops.
+            _demote = False
+            _padded_inputs = None
+            try:
+                mod = original_model.get_submodule(fqn)
+                fwd_sig = inspect.signature(mod.forward)
+                required = [
+                    p for p in fwd_sig.parameters.values()
+                    if p.name != 'self'
+                    and p.default is inspect.Parameter.empty
+                    and p.kind not in (
+                        inspect.Parameter.VAR_POSITIONAL,
+                        inspect.Parameter.VAR_KEYWORD,
+                    )
+                ]
+                if len(inputs) < len(required):
+                    n_missing = len(required) - len(inputs)
+                    if n_missing == 1:
+                        # Exactly 1 input is missing.  Find a suitable
+                        # substitute tensor from preceding call_module outputs.
+                        # The missing param is typically a "shape/device/dtype
+                        # reference" (like x in LlamaRotaryEmbedding) that the
+                        # module only uses for metadata, not for computation.
+                        _sub_tensor = None
+                        for prev_node in reversed(list(new_graph.nodes)):
+                            if prev_node.op == 'call_module':
+                                _sub_tensor = prev_node
+                                break
+                        if _sub_tensor is not None:
+                            # Prepend the substitute as the first arg
+                            # (the missing param is typically the first one)
+                            _padded_inputs = [_sub_tensor] + inputs
+                            if int(os.environ.get("RANK", "0")) == 0:
+                                print(f">> [IR] Padded missing input for "
+                                      f"'{fqn}' with preceding "
+                                      f"call_module '{_sub_tensor.name}'")
+                        else:
+                            _demote = True
+                    else:
+                        _demote = True
+            except (AttributeError, ValueError):
+                pass
+
+            if _demote:
+                if int(os.environ.get("RANK", "0")) == 0:
+                    print(f">> [IR] DEMOTED '{fqn}' to inline "
+                          f"({len(inputs)} inputs vs {len(required)} required)")
+                _emit_inline(nodes)
+                continue
+
+            # Find outputs: nodes from this region used outside
+            outputs = []
+            seen_outputs = set()
+            for n in nodes:
+                for user in n.users:
+                    if user not in node_set and user.op != 'output':
+                        if id(n) not in seen_outputs:
+                            outputs.append(n)
+                            seen_outputs.add(id(n))
+                            break
+                # Also check if this node is referenced by the graph's output node
+                if id(n) not in seen_outputs:
+                    for user in n.users:
+                        if user.op == 'output':
+                            outputs.append(n)
+                            seen_outputs.add(id(n))
+                            break
+
+            # Create call_module node
+            # _padded_inputs contains new-graph nodes for the substitute(s)
+            # followed by old-graph nodes for the real inputs.
+            if _padded_inputs is not None:
+                # The substitute tensor is already a new-graph node;
+                # the rest need remapping from old graph → new graph.
+                call_args = tuple(
+                    inp if inp.graph is new_graph else _remap(inp)
+                    for inp in _padded_inputs
+                )
+            else:
+                call_args = tuple(_remap(inp) for inp in inputs)
+            call_name = _make_name(fqn)
+            call_node = new_graph.call_module(fqn, args=call_args)
+            call_node.name = call_name
+
+            # Map outputs
+            if len(outputs) == 0:
+                if nodes:
+                    value_map[nodes[-1]] = call_node
+            elif len(outputs) == 1:
+                value_map[outputs[0]] = call_node
+            else:
+                for i, out_node in enumerate(outputs):
+                    gi_name = _make_name(f"getitem_{fqn}")
+                    gi_node = new_graph.call_function(
+                        operator.getitem, args=(call_node, i)
+                    )
+                    gi_node.name = gi_name
+                    value_map[out_node] = gi_node
+
+        else:
+            # Inline region
+            _emit_inline(region['nodes'])
+
+    # 5c. Create output node
+    output_nodes = [n for n in flat_graph.nodes if n.op == 'output']
+    if output_nodes:
+        orig_output = output_nodes[0]
+        try:
+            new_output_args = _remap_all(orig_output.args[0])
+        except (KeyError, TypeError):
+            # Fallback: find the last call_module node as output
+            last_call = None
+            for n in reversed(list(new_graph.nodes)):
+                if n.op == 'call_module':
+                    last_call = n
+                    break
+            new_output_args = (last_call,) if last_call else ()
+        new_graph.output(new_output_args)
+
+    # ── Step 6: Create GraphModule ──
+    # torch.export (strict=False) may create synthetic submodules (submod_0,
+    # submod_1, ...) for @torch.no_grad() wrappers.  These exist on flat_gm
+    # but not on original_model.  Temporarily register them so that
+    # GraphModule.__init__ can copy the attributes via _copy_attr.
+    _synthetic = []
+    for node in new_graph.nodes:
+        if node.op == 'get_attr':
+            first = node.target.split('.')[0]
+            if not hasattr(original_model, first) and hasattr(flat_gm, first):
+                original_model.add_module(first, getattr(flat_gm, first))
+                _synthetic.append(first)
+
+    new_graph.lint()
+    gm = GraphModule(original_model, new_graph)
+
+    # Clean up: remove synthetic modules from original_model
+    for name in _synthetic:
+        delattr(original_model, name)
+
+    # Report skipped nodes summary
+    if _skipped_nodes_info and int(os.environ.get("RANK", "0")) == 0:
+        print(f">> [IR] WARNING: {len(_skipped_nodes_info)} inline node(s) were "
+              f"SKIPPED during graph reconstruction!")
+        for name, tgt, err in _skipped_nodes_info:
+            print(f">>   SKIPPED: {name} (target={tgt}): {err}")
+    elif int(os.environ.get("RANK", "0")) == 0:
+        print(f">> [IR] Graph reconstruction: 0 nodes skipped (all inline ops preserved)")
+
+    return gm
 
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
@@ -70,6 +877,7 @@ class IR_Anal(Enum):
 
 _OTHER_MODELS = [
         "WhisperForCausalLM",
+        "Qwen2MoeForCausalLM",
         ]
 
 class IR(object):
@@ -84,13 +892,21 @@ class IR(object):
         self.special_nodes: Dict[str, Tuple[int, int]] = {}  # { node_name : {stage#, needed-by-stage#),}
 
 
-    def retrieve_IR(self, model: nn.Module, use_kv_cache: bool = False):
+    def retrieve_IR(self, model: nn.Module, use_kv_cache: bool = False, dynamo_capture: bool = False, for_training: bool = True):
+
+        self.dynamo_capture = dynamo_capture
+
+        if dynamo_capture:
+            return self._retrieve_IR_export(model, use_kv_cache, for_training=for_training)
+        else:
+            return self._retrieve_IR_trace(model, use_kv_cache)
+
+
+    def _retrieve_IR_trace(self, model: nn.Module, use_kv_cache: bool = False):
+        """Existing HFTracer / symbolic_trace path (unchanged)."""
 
         ##
         if model.__class__.__name__ in [ "ViTForImageClassification" ]:
-            #input_names = model.dummy_inputs.keys()
-            #input_names = list(model.dummy_inputs.keys())
-            #input_names = input_names + ['pixel_values']
             input_names = ['pixel_values']
             print(f" vit >> input_names: {input_names}")
 
@@ -107,7 +923,6 @@ class IR(object):
             self.gm = torch.fx.GraphModule(model, traced_graph)
             return self.optimus.model2type["vt"]
 
-        #elif model.__class__.__name__ in _SUPPORTED_MODELS:
         elif model.__class__.__name__ in _SUPPORTED_MODELS or model.__class__.__name__ in _OTHER_MODELS:
             input_names = list(model.dummy_inputs.keys())
             if use_kv_cache:
@@ -134,6 +949,460 @@ class IR(object):
         else:
             print(f"Not supported model!")
             sys.exit(1)
+
+
+    def _build_dynamic_shapes(self, input_names: List[str], example_inputs: dict,
+                              model: nn.Module = None):
+        """Build dynamic_shapes spec so torch.export doesn't bake in example sizes.
+
+        Without this, inline call_function nodes (view, reshape, etc.) would
+        contain literal shape values from the example inputs, causing shape
+        mismatches at runtime with different sequence lengths.
+
+        Returns a dict keyed by input name (matching kwargs passed to export()).
+        """
+        from torch.export import Dim
+
+        batch_dim = Dim("batch", min=1, max=256)
+
+        # Cap seq_len max from the model's position embedding table size.
+        # Use max_position_embeddings - 1 because models like BERT generate a
+        # Ne(max_pos, seq_len) guard — the exact boundary triggers
+        # specialization in torch.export.
+        seq_max = 16384
+        if model is not None and hasattr(model, 'config'):
+            mpe = getattr(model.config, 'max_position_embeddings', None)
+            if mpe is not None:
+                seq_max = mpe - 1
+        seq_dim = Dim("seq_len", min=1, max=seq_max)
+
+        # Text-model inputs that share the seq_len dimension
+        _SEQ_INPUTS = {'input_ids', 'position_ids', 'attention_mask', 'token_type_ids'}
+
+        specs = {}
+        for name in input_names:
+            tensor = example_inputs.get(name)
+            if tensor is None:
+                continue
+            ndim = tensor.dim()
+            if name in _SEQ_INPUTS and ndim >= 2:
+                specs[name] = {0: batch_dim, 1: seq_dim}
+            elif name == 'pixel_values' and ndim >= 1:
+                specs[name] = {0: batch_dim}
+            elif ndim >= 1:
+                specs[name] = {0: batch_dim}
+        return specs
+
+    def _retrieve_IR_export(self, model: nn.Module, use_kv_cache: bool = False, for_training: bool = True):
+        """torch.export.export() path — bypasses unflatten() entirely."""
+
+        if not _TORCH_EXPORT_AVAILABLE:
+            print(f"[IR] torch.export.export() requires PyTorch >= 2.4.0. "
+                  f"Current version: {torch.__version__}")
+            print(f"[IR] Please upgrade PyTorch or use dynamo_capture=False.")
+            sys.exit(1)
+
+        from torch.export import export
+
+        # For training (use_kv_cache=False), disable use_cache to simplify the
+        # export graph.  With use_cache=True, past_key_values are computed and
+        # included in the output, creating a complex tuple that confuses the
+        # pipeline split and loss computation.  Models like OPT load from
+        # pretrained with use_cache=True by default, unlike LLaMA examples
+        # which explicitly set use_cache=False.
+        _orig_use_cache = None
+        if (not use_kv_cache
+                and hasattr(model, 'config')
+                and getattr(model.config, 'use_cache', False)):
+            _orig_use_cache = model.config.use_cache
+            model.config.use_cache = False
+        # Determine input names and create example inputs
+        input_names = self._get_export_input_names(model, use_kv_cache)
+        example_inputs = self._create_example_inputs(model, input_names)
+
+        # Mark batch and seq_len dimensions as dynamic so the exported graph
+        # doesn't hardcode the example-input shapes into view/reshape ops.
+        dynamic_shapes = self._build_dynamic_shapes(input_names, example_inputs, model)
+
+        # Export with strict=False (TorchDynamo non-strict mode)
+        # — supports more Python constructs (e.g., @torch.no_grad in LLaMA RoPE)
+        # IMPORTANT: Pass inputs as kwargs (not positional args) so each tensor
+        # binds to the correct parameter name in forward().  Positional args
+        # would mis-bind (e.g., position_ids going to attention_mask).
+        #
+        # Always export in TRAINING mode for training.  This is critical
+        # because TorchDynamo bakes the model.training flag into the ATen
+        # graph:
+        #   - Dropout: eval-mode drops all ATen ops → dropout never applied
+        #   - _update_causal_mask (LLaMA): eval returns explicit 4D mask →
+        #     SDPA uses math kernel instead of Flash Attention → different
+        #     backward gradients → training divergence
+        # For inference (for_training=False), keep eval mode.
+        _has_active_dropout = False
+        if for_training:
+            for m in model.modules():
+                if isinstance(m, nn.Dropout) and m.p > 0:
+                    _has_active_dropout = True
+                    break
+
+        _was_training = model.training
+        if for_training:
+            model.train()  # Training path: bake training-mode behavior
+            if int(os.environ.get("RANK", "0")) == 0:
+                if _has_active_dropout:
+                    print(f">> [IR] Exporting in TRAINING mode (has active Dropout)")
+                else:
+                    print(f">> [IR] Exporting in TRAINING mode (for correct SDPA kernel selection)")
+        exported_program = export(
+            model, args=(), kwargs=example_inputs, strict=False,
+            dynamic_shapes=dynamic_shapes,
+        )
+        model.train(_was_training)  # Restore original mode
+        # Restore original use_cache setting
+        if _orig_use_cache is not None:
+            model.config.use_cache = _orig_use_cache
+
+        # Reconstruct module-level graph from nn_module_stack metadata
+        # (bypasses unflatten() which is broken for LLaMA — PyTorch #147348)
+        self.gm = build_module_graph_from_export(exported_program, model, input_names)
+
+        if int(os.environ.get("RANK", "0")) == 0:
+            n_call_module = sum(1 for n in self.gm.graph.nodes if n.op == 'call_module')
+            n_call_function = sum(1 for n in self.gm.graph.nodes if n.op == 'call_function')
+            n_get_attr = sum(1 for n in self.gm.graph.nodes if n.op == 'get_attr')
+            print(f">> [IR] torch.export path: {n_call_module} call_module, "
+                  f"{n_call_function} call_function, {n_get_attr} get_attr nodes")
+
+        # Save example inputs and flags for split verification later
+        self._export_example_inputs = example_inputs
+        self._export_model_ref = model  # weak reference for verify only
+        self._exported_for_training = for_training
+        self._has_baked_dropout = _has_active_dropout
+
+        # ── Verify reconstructed graph against original model ──
+        if int(os.environ.get("RANK", "0")) == 0:
+            self._verify_graph_output(model, example_inputs,
+                                         for_training=for_training,
+                                         has_baked_dropout=_has_active_dropout)
+
+        # Determine model type
+        if model.__class__.__name__ in ["ViTForImageClassification"]:
+            return self.optimus.model2type["vt"]
+        elif (model.__class__.__name__ in _SUPPORTED_MODELS
+              or model.__class__.__name__ in _OTHER_MODELS):
+            return self.optimus.model2type["hf"]
+        elif isinstance(model, nn.Module):
+            return self.optimus.model2type["sy"]
+        else:
+            print(f"Not supported model!")
+            sys.exit(1)
+
+
+    def _verify_graph_output(self, model, example_inputs,
+                             for_training=False, has_baked_dropout=False):
+        """Compare reconstructed GraphModule output with original model output.
+
+        This diagnostic helps pinpoint whether training divergence originates
+        from the graph reconstruction or from the split/schedule.
+
+        When has_baked_dropout=True, the GM contains baked dropout ATen ops
+        that run even in eval mode.  Comparing with the eval-mode model is
+        invalid (different dropout behavior), so we compare GM-vs-GM with the
+        same seed for deterministic consistency.
+
+        When for_training=True but has_baked_dropout=False (e.g., LLaMA), the
+        GM has baked training-mode behavior (_update_causal_mask returns None).
+        We compare GM vs model-in-training-mode, which is deterministic.
+        """
+        _was_training = model.training
+        try:
+            if for_training and not has_baked_dropout:
+                # Training-mode export without dropout (e.g., LLaMA):
+                # compare with model in training mode (deterministic)
+                model.train()
+                self.gm.train()
+            else:
+                model.eval()
+                self.gm.eval()
+
+            with torch.no_grad():
+                # Build GM inputs (match placeholder names)
+                gm_inputs = {}
+                for node in self.gm.graph.nodes:
+                    if node.op == 'placeholder':
+                        pname = node.name
+                        for k in example_inputs:
+                            if k == pname or pname.startswith(k):
+                                gm_inputs[pname] = example_inputs[k]
+                                break
+                if not gm_inputs:
+                    gm_inputs = example_inputs
+
+                if has_baked_dropout:
+                    # Graph has baked training-mode dropout ops.  Comparing
+                    # with the model is invalid.  Verify GM-vs-GM consistency
+                    # with a fixed seed instead.
+                    torch.manual_seed(42)
+                    gm_out1 = self.gm(**gm_inputs)
+                    torch.manual_seed(42)
+                    gm_out2 = self.gm(**gm_inputs)
+
+                    gm1 = gm_out1[0] if isinstance(gm_out1, tuple) else gm_out1
+                    gm2 = gm_out2[0] if isinstance(gm_out2, tuple) else gm_out2
+
+                    if isinstance(gm1, torch.Tensor) and isinstance(gm2, torch.Tensor):
+                        diff = (gm1.float() - gm2.float()).abs().max().item()
+                        print(f">> [VERIFY] Exported in TRAINING mode (baked dropout) "
+                              f"— eval-mode comparison skipped.")
+                        print(f">> [VERIFY] GM-vs-GM consistency (same seed): "
+                              f"max_diff={diff:.6e} "
+                              f"{'OK' if diff < 1e-3 else 'INCONSISTENT'}")
+                    return
+
+                # Standard comparison (eval-mode or training-mode without dropout)
+                orig_out = model(**example_inputs)
+                gm_out = self.gm(**gm_inputs)
+
+                # Extract logits from both outputs
+                if hasattr(orig_out, 'logits'):
+                    orig_logits = orig_out.logits
+                elif isinstance(orig_out, tuple):
+                    orig_logits = orig_out[0]
+                elif isinstance(orig_out, torch.Tensor):
+                    orig_logits = orig_out
+                else:
+                    print(f">> [VERIFY] Cannot extract logits from original output "
+                          f"(type={type(orig_out).__name__})")
+                    return
+
+                if isinstance(gm_out, tuple):
+                    gm_logits = gm_out[0]
+                elif isinstance(gm_out, torch.Tensor):
+                    gm_logits = gm_out
+                else:
+                    print(f">> [VERIFY] Cannot extract logits from GM output "
+                          f"(type={type(gm_out).__name__})")
+                    return
+
+                # Compare
+                if orig_logits.shape != gm_logits.shape:
+                    print(f">> [VERIFY] SHAPE MISMATCH: orig={orig_logits.shape}, "
+                          f"gm={gm_logits.shape}")
+                    return
+
+                abs_diff = (orig_logits.float() - gm_logits.float()).abs()
+                max_diff = abs_diff.max().item()
+                mean_diff = abs_diff.mean().item()
+                rel_diff = (abs_diff / (orig_logits.float().abs() + 1e-8)).mean().item()
+
+                orig_nan = torch.isnan(orig_logits).any().item()
+                gm_nan = torch.isnan(gm_logits).any().item()
+
+                status = "OK" if max_diff < 1e-3 else "MISMATCH"
+                if gm_nan and not orig_nan:
+                    status = "NaN in GM output!"
+
+                print(f">> [VERIFY] Graph reconstruction {status}: "
+                      f"max_diff={max_diff:.6e}, mean_diff={mean_diff:.6e}, "
+                      f"rel_diff={rel_diff:.6e}")
+                if max_diff >= 1e-3:
+                    print(f">> [VERIFY] WARNING: Large output difference detected!")
+                    flat_orig = orig_logits.flatten()[:5]
+                    flat_gm = gm_logits.flatten()[:5]
+                    print(f">>   orig[:5] = {flat_orig.tolist()}")
+                    print(f">>   gm[:5]   = {flat_gm.tolist()}")
+
+        except Exception as e:
+            print(f">> [VERIFY] Verification failed with error: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            # Restore original mode
+            model.train(_was_training)
+
+
+    def _verify_split_output(self):
+        """Compare split GraphModule output with original model output.
+
+        This verifies that split_module + post-processing (get_attr moves)
+        doesn't introduce numerical differences.
+        """
+        model = getattr(self, '_export_model_ref', None)
+        example_inputs = getattr(self, '_export_example_inputs', None)
+        if model is None or example_inputs is None:
+            return
+
+        # Check if we exported in training mode (for_training=True)
+        # If so, compare in training mode to match baked graph behavior
+        _exported_for_training = getattr(self, '_exported_for_training', False)
+        _has_baked_dropout = getattr(self, '_has_baked_dropout', False)
+
+        _was_training = model.training
+        try:
+            if _exported_for_training and not _has_baked_dropout:
+                model.train()
+                split_gm = self.model_ir[0]
+                split_gm.train()
+            else:
+                model.eval()
+                split_gm = self.model_ir[0]
+                split_gm.eval()
+
+            with torch.no_grad():
+                orig_out = model(**example_inputs)
+
+                # Run split graph — map placeholder names
+                split_inputs = {}
+                for node in split_gm.graph.nodes:
+                    if node.op == 'placeholder':
+                        for k in example_inputs:
+                            if k == node.name or node.name.startswith(k):
+                                split_inputs[node.name] = example_inputs[k]
+                                break
+                if not split_inputs:
+                    split_inputs = example_inputs
+
+                split_out = split_gm(**split_inputs)
+
+                # Extract logits
+                if hasattr(orig_out, 'logits'):
+                    orig_logits = orig_out.logits
+                elif isinstance(orig_out, tuple):
+                    orig_logits = orig_out[0]
+                elif isinstance(orig_out, torch.Tensor):
+                    orig_logits = orig_out
+                else:
+                    print(f">> [VERIFY-SPLIT] Cannot extract logits from orig output")
+                    return
+
+                if isinstance(split_out, tuple):
+                    split_logits = split_out[0]
+                elif isinstance(split_out, torch.Tensor):
+                    split_logits = split_out
+                else:
+                    print(f">> [VERIFY-SPLIT] Cannot extract logits from split output "
+                          f"(type={type(split_out).__name__})")
+                    return
+
+                if orig_logits.shape != split_logits.shape:
+                    print(f">> [VERIFY-SPLIT] SHAPE MISMATCH: orig={orig_logits.shape}, "
+                          f"split={split_logits.shape}")
+                    return
+
+                abs_diff = (orig_logits.float() - split_logits.float()).abs()
+                max_diff = abs_diff.max().item()
+                mean_diff = abs_diff.mean().item()
+
+                status = "OK" if max_diff < 1e-3 else "MISMATCH"
+                print(f">> [VERIFY-SPLIT] Split graph {status}: "
+                      f"max_diff={max_diff:.6e}, mean_diff={mean_diff:.6e}")
+                if max_diff >= 1e-3:
+                    print(f">> [VERIFY-SPLIT] WARNING: split_module introduced numerical errors!")
+
+        except Exception as e:
+            print(f">> [VERIFY-SPLIT] Failed: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            model.train(_was_training)
+
+        # Clean up references
+        self._export_model_ref = None
+        self._export_example_inputs = None
+
+
+    def _get_export_input_names(self, model: nn.Module, use_kv_cache: bool) -> List[str]:
+        """Determine input names for torch.export based on model type."""
+        if model.__class__.__name__ in ["ViTForImageClassification"]:
+            return ['pixel_values']
+        elif (model.__class__.__name__ in _SUPPORTED_MODELS
+              or model.__class__.__name__ in _OTHER_MODELS):
+            input_names = list(model.dummy_inputs.keys())
+            if use_kv_cache:
+                if 'position_ids' not in input_names:
+                    input_names.append('position_ids')
+            return input_names
+        else:
+            # Generic model: try to infer from forward signature
+            sig = inspect.signature(model.forward)
+            return [
+                p.name for p in sig.parameters.values()
+                if p.default is inspect.Parameter.empty and p.name != 'self'
+            ]
+
+
+    def _create_example_inputs(self, model: nn.Module, input_names: List[str]) -> dict:
+        """Create example input tensors for torch.export.export().
+
+        Returns a dict keyed by parameter name so they can be passed as
+        kwargs to export(), ensuring correct parameter-name matching
+        regardless of positional ordering in the model's forward().
+        """
+        inputs = {}
+
+        # Try model.dummy_inputs first (HuggingFace models)
+        if hasattr(model, 'dummy_inputs'):
+            dummy = model.dummy_inputs
+
+            # Avoid using seq_len == max_position_embeddings as the example.
+            # torch.export specializes on boundary values, generating guards
+            # like Ne(max_pos, seq_len) that conflict with dynamic_shapes.
+            _max_pos = None
+            if hasattr(model, 'config'):
+                _max_pos = getattr(model.config, 'max_position_embeddings', None)
+
+            for name in input_names:
+                if name in dummy:
+                    t = dummy[name]
+                    if (_max_pos is not None
+                            and t.dim() >= 2 and t.size(1) == _max_pos):
+                        t = t[:, :min(8, _max_pos)]
+                    inputs[name] = t
+                elif name == 'position_ids':
+                    # Generate position_ids matching both batch and seq_len of input_ids
+                    if 'input_ids' in dummy:
+                        batch_size = dummy['input_ids'].size(0)
+                        seq_len = dummy['input_ids'].size(1)
+                    else:
+                        batch_size, seq_len = 1, 8
+                    inputs[name] = (
+                        torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
+                    )
+                else:
+                    print(f"[IR] Warning: input '{name}' not found in dummy_inputs")
+
+            # torch.export specializes batch=1 as a constant.  Expand to
+            # batch>=2 so the batch dimension is treated as truly dynamic.
+            for name in list(inputs.keys()):
+                t = inputs[name]
+                if isinstance(t, torch.Tensor) and t.dim() >= 1 and t.size(0) == 1:
+                    inputs[name] = t.expand(2, *(-1,) * (t.dim() - 1)).contiguous()
+
+            if inputs:
+                return inputs
+
+        # Fallback: synthesize minimal inputs (batch=2 to avoid specialization)
+        # Try to infer input dimension from the first Linear layer
+        _first_linear_in = None
+        for m in model.modules():
+            if isinstance(m, nn.Linear):
+                _first_linear_in = m.in_features
+                break
+
+        for name in input_names:
+            if name == 'input_ids':
+                inputs[name] = torch.randint(0, 1000, (2, 8))
+            elif name == 'attention_mask':
+                inputs[name] = torch.ones(2, 8, dtype=torch.long)
+            elif name == 'position_ids':
+                inputs[name] = torch.arange(8).unsqueeze(0).expand(2, -1).contiguous()
+            elif name == 'pixel_values':
+                inputs[name] = torch.randn(2, 3, 224, 224)
+            else:
+                # Generic tensor input — use first Linear's in_features if available
+                in_dim = _first_linear_in or 64
+                inputs[name] = torch.randn(2, in_dim)
+        return inputs
 
 
     def split_IR(self, model: nn.Module, method, num_stage):
@@ -165,10 +1434,30 @@ class IR(object):
         self.model_ir.append(submods)
 
         if int(os.environ.get("RANK", "0")) == 0:
-            print(f">> ------------------ FX graph --------------------------------")
+            print(f">> ------------------ FX graph (split) --------------------------------")
+            n_split_cm = 0
+            n_split_cf = 0
+            n_split_ga = 0
             for n in self.model_ir[0].graph.nodes:
                 print(f"n.op:{n.op}, n.name:{n.name}, n.target:{n.target}, n.args:{n.args}, n.all_input_nodes:{n.all_input_nodes}")
+                if n.op == 'call_module':
+                    n_split_cm += 1
+                elif n.op == 'call_function':
+                    n_split_cf += 1
+                elif n.op == 'get_attr':
+                    n_split_ga += 1
+            print(f">> Split graph summary: {n_split_cm} call_module, "
+                  f"{n_split_cf} call_function, {n_split_ga} get_attr")
+            if n_split_cf > 0 or n_split_ga > 0:
+                print(f">> WARNING: {n_split_cf} call_function and {n_split_ga} get_attr "
+                      f"nodes at top level of split graph (not inside submodules)")
             print(f">> ------------------------------------------------------------")
+
+        # ── Verify split graph against original model ──
+        if (int(os.environ.get("RANK", "0")) == 0
+                and self.dynamo_capture
+                and hasattr(self, '_export_example_inputs')):
+            self._verify_split_output()
 
 
     def simple_split(self, module, num_stage):
@@ -283,28 +1572,42 @@ class IR(object):
             return use_indices[0]
 
 
-        remove_candidates = list()
-        for node in submodules.graph.nodes:
-            if node.op == "get_attr" and len(node.users) == 1:
-                user = list(node.users)[0]
-                assert user.op == "call_module"
-                use_index = remove_reference(node, user)
+        # Move parameters from get_attr nodes into submodules.
+        # With torch.export path, get_attr nodes for buffers used by inline
+        # call_function ops (e.g., RoPE inv_freq) should be skipped.
+        has_get_attr = any(n.op == "get_attr" for n in submodules.graph.nodes)
+        if has_get_attr:
+            remove_candidates = list()
+            for node in submodules.graph.nodes:
+                if node.op == "get_attr" and len(node.users) == 1:
+                    user = list(node.users)[0]
+                    if user.op == "call_function" or user.op == "call_method":
+                        # Inline op using a buffer — no submodule to move into
+                        continue
+                    assert user.op == "call_module", \
+                        f"get_attr '{node.target}' consumed by unexpected op: {user.op}"
 
-                atoms = node.target.split(".")
-                module_itr = submodules
-                for atom in atoms[:-1]:
-                    module_itr = getattr(module_itr, atom)
-                parameter_value = getattr(module_itr, atoms[-1])
-                _buffer = atoms[-1] in module_itr._buffers
+                    atoms = node.target.split(".")
+                    module_itr = submodules
+                    for atom in atoms[:-1]:
+                        module_itr = getattr(module_itr, atom)
+                    parameter_value = getattr(module_itr, atoms[-1])
 
-                move_parameters(submodules, user.target, parameter_value, use_index, _buffer)
+                    # Skip synthetic modules (e.g., submod_N from torch.export)
+                    if not isinstance(parameter_value, torch.Tensor):
+                        continue
 
-                remove_candidates.append((module_itr, atoms))
+                    _buffer = atoms[-1] in module_itr._buffers
+                    use_index = remove_reference(node, user)
 
-        for module_itr, atoms in remove_candidates:
-            delattr(module_itr, atoms[-1])
-        submodules.graph.lint()
-        submodules.recompile()
+                    move_parameters(submodules, user.target, parameter_value, use_index, _buffer)
+
+                    remove_candidates.append((module_itr, atoms))
+
+            for module_itr, atoms in remove_candidates:
+                delattr(module_itr, atoms[-1])
+            submodules.graph.lint()
+            submodules.recompile()
 
         self.metadata_range = []
 
@@ -460,28 +1763,39 @@ class IR(object):
 
             return use_indices[0]
 
-        remove_candidates = list()
-        for node in submodules.graph.nodes:
-            if node.op == "get_attr" and len(node.users) == 1:
-                user = list(node.users)[0]
-                assert user.op == "call_module"
-                use_index = remove_reference(node, user)
+        has_get_attr = any(n.op == "get_attr" for n in submodules.graph.nodes)
+        if has_get_attr:
+            remove_candidates = list()
+            for node in submodules.graph.nodes:
+                if node.op == "get_attr" and len(node.users) == 1:
+                    user = list(node.users)[0]
+                    if user.op == "call_function" or user.op == "call_method":
+                        # Inline op using a buffer — no submodule to move into
+                        continue
+                    assert user.op == "call_module", \
+                        f"get_attr '{node.target}' consumed by unexpected op: {user.op}"
 
-                atoms = node.target.split(".")
-                module_itr = submodules
-                for atom in atoms[:-1]:
-                    module_itr = getattr(module_itr, atom)
-                parameter_value = getattr(module_itr, atoms[-1])
-                _buffer = atoms[-1] in module_itr._buffers
+                    atoms = node.target.split(".")
+                    module_itr = submodules
+                    for atom in atoms[:-1]:
+                        module_itr = getattr(module_itr, atom)
+                    parameter_value = getattr(module_itr, atoms[-1])
 
-                move_parameters(submodules, user.target, parameter_value, use_index, _buffer)
+                    # Skip synthetic modules (e.g., submod_N from torch.export)
+                    if not isinstance(parameter_value, torch.Tensor):
+                        continue
 
-                remove_candidates.append((module_itr, atoms))
+                    _buffer = atoms[-1] in module_itr._buffers
+                    use_index = remove_reference(node, user)
 
-        for module_itr, atoms in remove_candidates:
-            delattr(module_itr, atoms[-1])
-        submodules.graph.lint()
-        submodules.recompile()
+                    move_parameters(submodules, user.target, parameter_value, use_index, _buffer)
+
+                    remove_candidates.append((module_itr, atoms))
+
+            for module_itr, atoms in remove_candidates:
+                delattr(module_itr, atoms[-1])
+            submodules.graph.lint()
+            submodules.recompile()
 
         self.metadata_range = []
 
@@ -644,7 +1958,7 @@ class IR(object):
                 self.optimus.run_info.name = n
                 self.optimus.run_info.submod = m
                 break
-        
+
         if self.optimus.run_info.name is None:
             print(f"ERROR: Not found name(submod_{stage})")
             sys.exit(0)
@@ -659,10 +1973,6 @@ class IR(object):
         if self.optimus.run_info.node is None:
             print(f"ERROR: Not found node({self.name})")
             sys.exit(0)
-
-
-        #self.submod.to(self.run_info.device)
-        #print(f" ## Rank:{rank}, name:{self.optimus.run_info.node.name}, move {self.optimus.run_info.name} to {self.optimus.run_info.device}")
 
 
     def build_getitem_dic(self):

--- a/opt_prime/opt_prime/IR.py
+++ b/opt_prime/opt_prime/IR.py
@@ -1016,6 +1016,18 @@ class IR(object):
                 and getattr(model.config, 'use_cache', False)):
             _orig_use_cache = model.config.use_cache
             model.config.use_cache = False
+
+        # Disable layerdrop before export.  Models like Whisper use
+        # data-dependent control flow (`random.uniform() < layerdrop`) inside
+        # an `if self.training:` guard.  torch.export cannot handle
+        # data-dependent branches (even with layerdrop=0.0, random.uniform
+        # creates an unbacked symbolic value during tracing).
+        # Fix: after model.train(), set training=False on modules with
+        # layerdrop so the `if self.training:` guard is never entered.
+        _layerdrop_modules = []
+        for mod in model.modules():
+            if hasattr(mod, 'layerdrop'):
+                _layerdrop_modules.append(mod)
         # Determine input names and create example inputs
         input_names = self._get_export_input_names(model, use_kv_cache)
         example_inputs = self._create_example_inputs(model, input_names)
@@ -1053,14 +1065,74 @@ class IR(object):
                     print(f">> [IR] Exporting in TRAINING mode (has active Dropout)")
                 else:
                     print(f">> [IR] Exporting in TRAINING mode (for correct SDPA kernel selection)")
-        exported_program = export(
-            model, args=(), kwargs=example_inputs, strict=False,
-            dynamic_shapes=dynamic_shapes,
-        )
+
+        # After model.train(), disable training on modules with layerdrop
+        # so `if self.training:` guard around random.uniform is never entered.
+        if _layerdrop_modules:
+            for mod in _layerdrop_modules:
+                mod.training = False
+            if int(os.environ.get("RANK", "0")) == 0:
+                print(f">> [IR] Disabled training on {len(_layerdrop_modules)} "
+                      f"module(s) with layerdrop to avoid data-dependent control flow")
+
+        # Patch _update_causal_mask to return None during training-mode export.
+        # Models like GPT-2 compute an explicit causal mask at the top of the
+        # model (in _update_causal_mask) and pass it to ALL attention layers,
+        # creating a global skip connection.  After pipeline split, this mask
+        # ends up in one stage but is needed by all stages — the schedule
+        # cannot propagate it correctly.  By returning None, each attention
+        # layer uses its own internal self.bias buffer for causal masking,
+        # keeping the mask local to each layer (no skip connection).
+        # LLaMA already returns None in training mode, so this is a no-op
+        # for LLaMA.  For inference (for_training=False), skip the patch.
+        # NOTE: Some models (e.g., OPT) return a tuple from _update_causal_mask
+        # and rely on the external mask for causal attention (no internal
+        # self.bias fallback).  For these, the patch would break unpacking
+        # and remove causal masking.  We detect this via try/except: if export
+        # fails with TypeError (tuple unpack), we revert and retry.
+        _orig_update_causal_mask = None
+        if for_training:
+            for mod in model.modules():
+                if hasattr(mod, '_update_causal_mask') and callable(mod._update_causal_mask):
+                    _orig_update_causal_mask = (mod, mod._update_causal_mask)
+                    mod._update_causal_mask = lambda *a, **kw: None
+                    if int(os.environ.get("RANK", "0")) == 0:
+                        print(f">> [IR] Patched _update_causal_mask → None "
+                              f"(avoid global mask skip connection)")
+                    break
+
+        try:
+            exported_program = export(
+                model, args=(), kwargs=example_inputs, strict=False,
+                dynamic_shapes=dynamic_shapes,
+            )
+        except TypeError as e:
+            if _orig_update_causal_mask is not None and (
+                    'unpack' in str(e) or 'NoneType' in str(e)):
+                # _update_causal_mask returns a tuple (e.g., OPT) — revert patch
+                mod_ref, orig_fn = _orig_update_causal_mask
+                mod_ref._update_causal_mask = orig_fn
+                _orig_update_causal_mask = None
+                if int(os.environ.get("RANK", "0")) == 0:
+                    print(f">> [IR] _update_causal_mask returns tuple; "
+                          f"reverted patch and retrying export")
+                exported_program = export(
+                    model, args=(), kwargs=example_inputs, strict=False,
+                    dynamic_shapes=dynamic_shapes,
+                )
+            else:
+                raise
         model.train(_was_training)  # Restore original mode
         # Restore original use_cache setting
         if _orig_use_cache is not None:
             model.config.use_cache = _orig_use_cache
+        # Restore training mode on layerdrop modules
+        for mod in _layerdrop_modules:
+            mod.training = True
+        # Restore _update_causal_mask
+        if _orig_update_causal_mask is not None:
+            mod_ref, orig_fn = _orig_update_causal_mask
+            mod_ref._update_causal_mask = orig_fn
 
         # Reconstruct module-level graph from nn_module_stack metadata
         # (bypasses unflatten() which is broken for LLaMA — PyTorch #147348)

--- a/opt_prime/opt_prime/inference.py
+++ b/opt_prime/opt_prime/inference.py
@@ -163,7 +163,7 @@ class Optimus_Inference:
 
         # Initialize IR and split model
         self.ir = IR(module, self)
-        self.model_type = self.ir.retrieve_IR(module, use_kv_cache=use_kv_cache, dynamo_capture=dynamo_capture, for_training=False)
+        self.model_type = self.ir.retrieve_IR(module, use_kv_cache=self.use_kv_cache, dynamo_capture=dynamo_capture, for_training=False)
         self.ir.split_IR(module, split_method, num_stage=self.tpl.get_num_stage())
         self.ir.setup_submod(self.tpl.stage, rank)
         self.ir.build_getitem_dic()
@@ -792,8 +792,9 @@ class Optimus_Inference:
         Returns:
             Generated token IDs if this is the last stage, None otherwise
         """
-        if self._schedule_infer is None:
-            self._schedule_infer = ScheduleInference(self)
+        # Use ScheduleGeneration for explicit prefill/decode phases
+        if self._schedule_gen is None:
+            self._schedule_gen = ScheduleGeneration(self)
 
         # Enable/reset all CachedSDPA modules
         for m in self._cached_sdpa_modules:
@@ -801,7 +802,6 @@ class Optimus_Inference:
                 m.clear()    # Already allocated — reset position only
             else:
                 m.enable()   # First call or batch mode — activate
-
 
         # Reset KVCacheManager for new generation
         if self.use_kv_manager and self.kv_cache is not None:
@@ -844,21 +844,10 @@ class Optimus_Inference:
         num_generated = 0
 
         # === PREFILL: forward the entire prompt ===
-        if self.tpl.is_first_stage():
-            position_ids = torch.arange(
-                input_seq_len, device=self.device
-            ).unsqueeze(0).expand(batch_size, -1)
-            full_output = self._schedule_infer.run(input_ids, position_ids=position_ids)
-        else:
-            full_output = self._schedule_infer.run(None)
+        logits = self._schedule_gen.prefill(input_ids)
 
         # Sample first token on last stage
         if self.tpl.is_last_stage():
-            if isinstance(full_output, torch.Tensor) and full_output.dim() >= 2:
-                logits = full_output[:, -1, :]
-            else:
-                logits = full_output
-
             next_token = self._sample_token(logits, temperature, top_k, top_p, do_sample)
 
             # Sync sampled token across TP ranks (sampling may diverge)
@@ -886,28 +875,31 @@ class Optimus_Inference:
             if self.tpl.is_first_stage() and not self.tpl.is_last_stage():
                 next_token = self.comm.receive_data(self.tpl.get_last_rank(), self.device)
 
+        # TP sync: broadcast sampled token within TP group
+        if self.tpl.tp_size > 1:
+            if next_token is None:
+                next_token = torch.zeros(1, dtype=torch.long, device=self.device)
+            dist.broadcast(
+                next_token,
+                src=self.tpl.stage2rank[self.tpl.stage][0],
+                group=self.tpl.tp_group,
+            )
+
         # === DECODE LOOP: one token at a time with KV cache ===
         for i in range(1, max_new_tokens):
-            # Forward single token with correct position
-            if self.tpl.is_first_stage():
-                cur_pos = input_seq_len + i - 1
-                position_ids = torch.tensor(
-                    [[cur_pos]], device=self.device
-                ).expand(batch_size, -1)
+            cur_pos = input_seq_len + i - 1
 
-                full_output = self._schedule_infer.run(
-                    next_token.unsqueeze(1), position_ids=position_ids
-                )
+            # Forward single token via decode_step
+            if self.tpl.is_first_stage():
+                token_input = next_token.unsqueeze(0) if next_token.dim() == 1 else next_token
+                if token_input.dim() == 1:
+                    token_input = token_input.unsqueeze(0)  # [1, 1]
+                logits = self._schedule_gen.decode_step(token_input, cur_pos)
             else:
-                full_output = self._schedule_infer.run(None)
+                logits = self._schedule_gen.decode_step(None, cur_pos)
 
             # Sample on last stage
             if self.tpl.is_last_stage():
-                if isinstance(full_output, torch.Tensor) and full_output.dim() >= 2:
-                    logits = full_output[:, -1, :]
-                else:
-                    logits = full_output
-
                 next_token = self._sample_token(
                     logits, temperature, top_k, top_p, do_sample
                 )
@@ -948,17 +940,28 @@ class Optimus_Inference:
                         self.tpl.get_last_rank(), self.device
                     )
 
+            # TP sync: broadcast sampled token within TP group
+            if self.tpl.tp_size > 1:
+                if next_token is None:
+                    next_token = torch.zeros(1, dtype=torch.long, device=self.device)
+                dist.broadcast(
+                    next_token,
+                    src=self.tpl.stage2rank[self.tpl.stage][0],
+                    group=self.tpl.tp_group,
+                )
+
         # Serving mode: keep cache allocated for next request (clear position only)
         # Batch mode: free cache memory completely
-        for m in self._cached_sdpa_modules:
-            if self.serving_mode:
-                m.clear()
-            else:
-                m.disable()
-
-        # Reset KVCacheManager position for next generation
-        if self.use_kv_manager and self.kv_cache is not None:
-            self.kv_cache.clear()
+        if self.use_kv_manager and not self.serving_mode:
+            self.release_kv_cache()
+        else:
+            for m in self._cached_sdpa_modules:
+                if self.serving_mode:
+                    m.clear()
+                else:
+                    m.disable()
+            if self.use_kv_manager and self.kv_cache is not None:
+                self.kv_cache.clear()
 
         # Trim generated_ids to actual length
         if self.tpl.is_last_stage():

--- a/opt_prime/opt_prime/inference.py
+++ b/opt_prime/opt_prime/inference.py
@@ -94,8 +94,10 @@ class Optimus_Inference:
         use_kv_cache: bool = False,
         serving_mode: bool = False,
         use_kv_manager: bool = False,
+        dynamo_capture: bool = False,
     ):
         self.use_gpu = use_gpu
+        self.dynamo_capture = dynamo_capture
         self.max_batch_size = max_batch_size
         self.max_seq_len = max_seq_len
         self.dtype = dtype
@@ -161,7 +163,7 @@ class Optimus_Inference:
 
         # Initialize IR and split model
         self.ir = IR(module, self)
-        self.model_type = self.ir.retrieve_IR(module, use_kv_cache=use_kv_cache)
+        self.model_type = self.ir.retrieve_IR(module, use_kv_cache=use_kv_cache, dynamo_capture=dynamo_capture, for_training=False)
         self.ir.split_IR(module, split_method, num_stage=self.tpl.get_num_stage())
         self.ir.setup_submod(self.tpl.stage, rank)
         self.ir.build_getitem_dic()
@@ -239,12 +241,88 @@ class Optimus_Inference:
 
         # Adjust view operations for TP
         for node in self.run_info.submod.graph.nodes:
+            # Match view nodes: call_method("view") or call_function(aten.view/reshape)
+            is_view = False
             if node.op == 'call_method' and node.name.startswith("view"):
+                is_view = True
+            elif node.op == 'call_function':
+                target_name = getattr(node.target, '__name__', str(node.target))
+                if 'view' in target_name or 'reshape' in target_name:
+                    is_view = True
+
+            if is_view:
                 result, layer_id = self._check_tp_post(node.args[0])
                 if result in [0, 1, 2]:  # Q, K, V projections
+                    tp_size = self.tpl.tp_mesh.size()
                     new_args = list(node.args)
-                    new_args[3] = new_args[3] // self.tpl.tp_mesh.size()
+                    if node.op == 'call_method' and len(new_args) > 3:
+                        # HFTracer: view(tensor, bs, seq, num_heads, head_dim)
+                        new_args[3] = new_args[3] // tp_size
+                    elif node.op == 'call_function' and len(new_args) >= 2 and isinstance(new_args[1], (list, tuple)):
+                        # torch.export: reshape(tensor, [bs, seq, num_heads, head_dim])
+                        shape = list(new_args[1])
+                        if len(shape) >= 3:
+                            shape[2] = shape[2] // tp_size
+                            new_args[1] = shape
                     node.args = tuple(new_args)
+
+        # Adjust GQA repeat_kv ops for TP (export path only).
+        # Pattern: unsqueeze(K/V, 2) → expand([B, kv_heads, n_rep, S, D])
+        #          → reshape([B, q_heads, S, D])
+        # After ColwiseParallel splits K/V proj weights, the actual kv_heads
+        # is halved but the hardcoded shape constants in expand/reshape are not.
+        tp_size = self.tpl.tp_mesh.size()
+        adjusted_expands = set()  # track which expand nodes were adjusted
+        for node in self.run_info.submod.graph.nodes:
+            if node.op != 'call_function':
+                continue
+            target_name = getattr(node.target, '__name__', str(node.target))
+
+            # expand with 5D shape: [B, kv_heads, n_rep, S, D]
+            if 'expand' in target_name:
+                if (len(node.args) >= 2
+                        and isinstance(node.args[1], (list, tuple))
+                        and len(node.args[1]) == 5):
+                    # Trace back through unsqueeze/transpose/reshape to K/V proj
+                    res, _ = self._trace_back_to_proj(node.args[0])
+                    if res in [1, 2]:  # K or V
+                        new_args = list(node.args)
+                        shape = list(new_args[1])
+                        if isinstance(shape[1], int):
+                            shape[1] = shape[1] // tp_size
+                        new_args[1] = shape
+                        node.args = tuple(new_args)
+                        adjusted_expands.add(node)
+
+            # reshape 5D→4D after a repeat_kv expand: [B, q_heads, S, D]
+            # The chain may be expand → clone → reshape (clone needed
+            # because expand produces non-contiguous view).
+            if 'reshape' in target_name or 'view' in target_name:
+                if (len(node.args) >= 2
+                        and isinstance(node.args[1], (list, tuple))
+                        and len(node.args[1]) == 4):
+                    # Trace back through clone/contiguous to find expand
+                    inp = node.args[0]
+                    found_expand = False
+                    for _ in range(3):  # at most a few intermediate ops
+                        if not isinstance(inp, torch.fx.Node):
+                            break
+                        if inp in adjusted_expands:
+                            found_expand = True
+                            break
+                        inp_name = getattr(inp.target, '__name__',
+                                           str(inp.target))
+                        if 'clone' in inp_name or 'contiguous' in inp_name:
+                            inp = inp.args[0] if inp.args else None
+                        else:
+                            break
+                    if found_expand:
+                        new_args = list(node.args)
+                        shape = list(new_args[1])
+                        if isinstance(shape[1], int):
+                            shape[1] = shape[1] // tp_size
+                        new_args[1] = shape
+                        node.args = tuple(new_args)
 
         self.run_info.submod.recompile()
         self.run_info.submod = parallelize_module(
@@ -269,6 +347,26 @@ class Optimus_Inference:
                 elif parts[5] == "v" and parts[6] == "proj":
                     return 2, layer_id
 
+        return -1, -1
+
+    def _trace_back_to_proj(self, node, max_depth: int = 10) -> Tuple[int, int]:
+        """Trace arg[0] chain back through intermediate ops to find Q/K/V proj.
+
+        Follows the first input argument of each node (reshape, transpose,
+        unsqueeze, etc.) up to max_depth steps until a Q/K/V projection
+        call_module node is found.
+        """
+        current = node
+        for _ in range(max_depth):
+            if not isinstance(current, torch.fx.Node):
+                return -1, -1
+            res, layer_id = self._check_tp_post(current)
+            if res >= 0:
+                return res, layer_id
+            if current.args and isinstance(current.args[0], torch.fx.Node):
+                current = current.args[0]
+            else:
+                return -1, -1
         return -1, -1
 
     def _prepare_dp_group(self) -> None:
@@ -704,6 +802,7 @@ class Optimus_Inference:
             else:
                 m.enable()   # First call or batch mode — activate
 
+
         # Reset KVCacheManager for new generation
         if self.use_kv_manager and self.kv_cache is not None:
             self.kv_cache.clear()
@@ -795,6 +894,7 @@ class Optimus_Inference:
                 position_ids = torch.tensor(
                     [[cur_pos]], device=self.device
                 ).expand(batch_size, -1)
+
                 full_output = self._schedule_infer.run(
                     next_token.unsqueeze(1), position_ids=position_ids
                 )

--- a/opt_prime/opt_prime/kv_cache.py
+++ b/opt_prime/opt_prime/kv_cache.py
@@ -402,10 +402,16 @@ class CachedScaledDotProductAttention(nn.Module):
                 dropout_p=dropout_p, is_causal=False, **kwargs,
             )
         else:
-            # Prefill: standard causal attention with original mask
+            # Prefill: use is_causal=True instead of the explicit attn_mask.
+            # The torch.export path can produce an incorrect causal mask
+            # (off-by-one in _update_causal_mask due to cache_position tracing),
+            # so we let SDPA compute its own causal mask which is always correct
+            # when Q_len == K_len (true during prefill).
+            # Drop 'scale' from kwargs if present — pass it explicitly to
+            # avoid any conflict between the mask kwarg and is_causal.
             return F.scaled_dot_product_attention(
-                query, full_key, full_value, attn_mask=attn_mask,
-                dropout_p=dropout_p, is_causal=is_causal, **kwargs,
+                query, full_key, full_value, attn_mask=None,
+                dropout_p=dropout_p, is_causal=True, **kwargs,
             )
 
     def __repr__(self) -> str:

--- a/opt_prime/opt_prime/opti_pri.py
+++ b/opt_prime/opt_prime/opti_pri.py
@@ -344,7 +344,7 @@ def print_cpu_memory_usage(str, print_flag = False):
 
 class Optimus_p:
 
-    def __init__(self, module:nn.Module, num_mb, use_gpu=False, pp_size=1, dp_size=1, tp_size=1, preserve_output=False, activation_ckpt=False, force_free_mem=False, display_mem=False, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze: IR_Anal = IR_Anal.PARALLEL, use_padding=True, pre_barrier=None, checkpoint=False, ckpt_dir_postfix: Optional[str]= None, prt_shape=False, swap_use_disk=False):
+    def __init__(self, module:nn.Module, num_mb, use_gpu=False, pp_size=1, dp_size=1, tp_size=1, preserve_output=False, activation_ckpt=False, force_free_mem=False, display_mem=False, swap_opt_in_fwdbwd=False, swap_model_in_optstep=False, ir_analyze: IR_Anal = IR_Anal.PARALLEL, use_padding=True, pre_barrier=None, checkpoint=False, ckpt_dir_postfix: Optional[str]= None, prt_shape=False, swap_use_disk=False, dynamo_capture=False):
 
         #self.model_ir = []
         self.num_mb = num_mb
@@ -352,6 +352,7 @@ class Optimus_p:
         #self.special_nodes: Dict[str, Tuple[int, int]] = {}  # { node_name : {stage#, needed-by-stage#),}
 
         self.use_gpu = use_gpu
+        self.dynamo_capture = dynamo_capture
 
         self.comm = Comm(use_gpu=use_gpu, ir_analyze=ir_analyze)
 
@@ -436,7 +437,7 @@ class Optimus_p:
                 if local_rank == i:
                     self.ir = IR(module, self)
 
-                    self.model_type = self.ir.retrieve_IR(module)
+                    self.model_type = self.ir.retrieve_IR(module, dynamo_capture=dynamo_capture)
                     #self.ir.split_IR(module, "simple", num_stage=self.tpl.get_num_stage())
                     self.ir.split_IR(module, split_method, num_stage=self.tpl.get_num_stage())
 
@@ -481,7 +482,7 @@ class Optimus_p:
             self.ir = IR(module, self)
             #self.model_ir.append(IR(module))
 
-            self.model_type = self.ir.retrieve_IR(module)
+            self.model_type = self.ir.retrieve_IR(module, dynamo_capture=dynamo_capture)
             #self.ir.split_IR(module, "simple", num_stage=self.tpl.get_num_stage())
             self.ir.split_IR(module, split_method, num_stage=self.tpl.get_num_stage())
 
@@ -788,6 +789,21 @@ class Optimus_p:
 
         return -1, -1
 
+    def _trace_back_to_proj(self, node, max_depth=10):
+        """Trace arg[0] chain back to find Q/K/V projection call_module."""
+        current = node
+        for _ in range(max_depth):
+            if not isinstance(current, torch.fx.Node):
+                return -1, -1
+            res, layer_id = self.check_tp_post(current)
+            if res >= 0:
+                return res, layer_id
+            if current.args and isinstance(current.args[0], torch.fx.Node):
+                current = current.args[0]
+            else:
+                return -1, -1
+        return -1, -1
+
     
     # TODO
     def prepare_tp_group(self):
@@ -823,30 +839,92 @@ class Optimus_p:
 
         print(f">>>> self.tpl.tp_mesh.size(): {self.tpl.tp_mesh.size()}")
 
+        tp_size = self.tpl.tp_mesh.size()
+
         for node in self.run_info.submod.graph.nodes:
+            # Match view nodes: call_method("view") or call_function(aten.view/reshape)
+            is_view = False
             if node.op == 'call_method' and node.name.startswith("view"):
+                is_view = True
+            elif node.op == 'call_function':
+                target_name = getattr(node.target, '__name__', str(node.target))
+                if 'view' in target_name or 'reshape' in target_name:
+                    is_view = True
+
+            if is_view:
+                # Only check direct arg[0] — do NOT trace back deeply here,
+                # as that would wrongly match GQA repeat_kv reshapes too.
                 result, layer_id = self.check_tp_post(node.args[0])
 
-                if result == 0:
-                    print(f">model_layers_{layer_id}_self_attn_q_proj ==> node.args[3]:{node.args[3]}")
+                if result in [0, 1, 2]:  # Q, K, V projections
                     new_args = list(node.args)
-                    new_args[3] = new_args[3] // self.tpl.tp_mesh.size()
+                    if node.op == 'call_method' and len(new_args) > 3:
+                        # HFTracer: view(tensor, bs, seq, num_heads, head_dim)
+                        print(f"> TP adjust view (HFTracer) layer_{layer_id} proj={result}: args[3]={new_args[3]} -> {new_args[3] // tp_size}")
+                        new_args[3] = new_args[3] // tp_size
+                    elif node.op == 'call_function' and len(new_args) >= 2 and isinstance(new_args[1], (list, tuple)):
+                        # torch.export: reshape(tensor, [bs, seq, num_heads, head_dim])
+                        shape = list(new_args[1])
+                        if len(shape) >= 3:
+                            print(f"> TP adjust reshape (export) layer_{layer_id} proj={result}: shape[2]={shape[2]} -> {shape[2] // tp_size}")
+                            shape[2] = shape[2] // tp_size
+                            new_args[1] = shape
                     node.args = tuple(new_args)
-                    print(f"> >model_layers_{layer_id}_self_attn_q_proj ==> node.args[3]:{node.args[3]}")
 
-                elif result == 1:
-                    print(f">>model_layers_{layer_id}_self_attn_k_proj ===> node.args[3]:{node.args[3]}")
-                    new_args = list(node.args)
-                    new_args[3] = new_args[3] // self.tpl.tp_mesh.size()
-                    node.args = tuple(new_args)
-                    print(f">> >> model_layers_{layer_id}_self_attn_k_proj ===> node.args[3]:{node.args[3]}")
+        # Adjust GQA repeat_kv ops for TP (export path only).
+        # Pattern: unsqueeze(K/V, 2) -> expand([B, kv_heads, n_rep, S, D])
+        #          -> clone -> reshape([B, q_heads, S, D])
+        # After ColwiseParallel splits K/V proj weights, the actual kv_heads
+        # is halved but the hardcoded shape constants in expand/reshape are not.
+        adjusted_expands = set()
+        for node in self.run_info.submod.graph.nodes:
+            if node.op != 'call_function':
+                continue
+            target_name = getattr(node.target, '__name__', str(node.target))
 
-                elif result == 2:
-                    print(f">>>model_layers_{layer_id}_self_attn_v_proj ===> node.args[3]:{node.args[3]}")
-                    new_args = list(node.args)
-                    new_args[3] = new_args[3] // self.tpl.tp_mesh.size()
-                    node.args = tuple(new_args)
-                    print(f">>> >>>model_layers_{layer_id}_self_attn_v_proj ===> node.args[3]:{node.args[3]}")
+            # expand with 5D shape: [B, kv_heads, n_rep, S, D]
+            if 'expand' in target_name:
+                if (len(node.args) >= 2
+                        and isinstance(node.args[1], (list, tuple))
+                        and len(node.args[1]) == 5):
+                    res, _ = self._trace_back_to_proj(node.args[0])
+                    if res in [1, 2]:  # K or V
+                        new_args = list(node.args)
+                        shape = list(new_args[1])
+                        if isinstance(shape[1], int):
+                            print(f"> TP adjust GQA expand: shape[1]={shape[1]} -> {shape[1] // tp_size}")
+                            shape[1] = shape[1] // tp_size
+                        new_args[1] = shape
+                        node.args = tuple(new_args)
+                        adjusted_expands.add(node)
+
+            # reshape 5D->4D after a repeat_kv expand: [B, q_heads, S, D]
+            # Chain may be expand -> clone -> reshape
+            if 'reshape' in target_name or 'view' in target_name:
+                if (len(node.args) >= 2
+                        and isinstance(node.args[1], (list, tuple))
+                        and len(node.args[1]) == 4):
+                    inp = node.args[0]
+                    found_expand = False
+                    for _ in range(3):
+                        if not isinstance(inp, torch.fx.Node):
+                            break
+                        if inp in adjusted_expands:
+                            found_expand = True
+                            break
+                        inp_name = getattr(inp.target, '__name__', str(inp.target))
+                        if 'clone' in inp_name or 'contiguous' in inp_name:
+                            inp = inp.args[0] if inp.args else None
+                        else:
+                            break
+                    if found_expand:
+                        new_args = list(node.args)
+                        shape = list(new_args[1])
+                        if isinstance(shape[1], int):
+                            print(f"> TP adjust GQA reshape: shape[1]={shape[1]} -> {shape[1] // tp_size}")
+                            shape[1] = shape[1] // tp_size
+                        new_args[1] = shape
+                        node.args = tuple(new_args)
 
         self.run_info.submod.recompile()
         self.run_info.submod = parallelize_module(module=self.run_info.submod, device_mesh=self.tpl.tp_mesh, parallelize_plan=tp_plan)

--- a/opt_prime/opt_prime/schedule.py
+++ b/opt_prime/opt_prime/schedule.py
@@ -121,11 +121,17 @@ class Schedule:
             print(f"optimus.optimizer not set when swap_opt_in_fwdbwd == True")
             return
 
-        state_dict = self.optimus.optimizer.state_dict()
-        for state in state_dict['state'].values():
+        # Iterate optimizer.state directly (NOT state_dict()) because
+        # PyTorch 2.5+ state_dict() returns copies via
+        # _process_value_according_to_param_policy, so modifying the
+        # returned dict does NOT update the actual optimizer state.
+        for param, state in self.optimus.optimizer.state.items():
             for k, v in state.items():
                 if isinstance(v, torch.Tensor):
-                    state[k] = v.cpu()
+                    if hasattr(v, 'to_local'):
+                        state[k] = v.to_local().detach().cpu()
+                    else:
+                        state[k] = v.cpu()
 
         if self.optimus.swap_use_disk == True:
             disk_path_opt = f"temp_optistat_{self.optimus.tpl.rank}"
@@ -148,18 +154,109 @@ class Schedule:
             self.optimus.optimizer.load_state_dict(opt_state['optimizer_state_dict'])
             #print(f"[R] optimizer state dict <-- DISK({disk_path_opt})")
 
-        state_dict = self.optimus.optimizer.state_dict()
-        for state in state_dict['state'].values():
+        # Use optimizer.state directly (same reason as offload_optimizer)
+        for param, state in self.optimus.optimizer.state.items():
             for k, v in state.items():
                 if isinstance(v, torch.Tensor):
                     state[k] = v.to(self.optimus.run_info.device)
+
+    def _move_params(self, device):
+        """Move parameters to device for CPU offload / GPU load-back.
+
+        For DTensor params (from TP): param.data = plain_tensor does NOT
+        strip the DTensor wrapper. So we REPLACE the Parameter objects in
+        optimizer.param_groups with new plain Parameters during offload,
+        and restore the original DTensor params during load-back (copying
+        the optimizer-updated values into the DTensor's local tensor).
+        """
+        submod = self.optimus.run_info.submod
+        is_offloading = (str(device) == 'cpu')
+
+        if is_offloading:
+            torch.cuda.synchronize()
+
+        if self.optimus.optimizer is not None:
+            for gi, group in enumerate(self.optimus.optimizer.param_groups):
+                for pi in range(len(group['params'])):
+                    p = group['params'][pi]
+
+                    if is_offloading:
+                        data = p.data
+                        if hasattr(data, 'to_local'):
+                            # --- DTensor param: replace with plain Parameter ---
+                            if not hasattr(self, '_dtensor_originals'):
+                                self._dtensor_originals = {}
+
+                            key = (gi, pi)
+                            self._dtensor_originals[key] = p  # keep original DTensor param
+
+                            # Create plain CPU parameter
+                            local_data = data.to_local().detach().cpu()
+                            new_p = torch.nn.Parameter(local_data, requires_grad=p.requires_grad)
+
+                            if p.grad is not None:
+                                grad = p.grad
+                                if hasattr(grad, 'to_local'):
+                                    grad = grad.to_local().detach()
+                                new_p.grad = grad.cpu()
+
+                            # Transfer optimizer state from old key to new key
+                            if p in self.optimus.optimizer.state:
+                                self.optimus.optimizer.state[new_p] = self.optimus.optimizer.state.pop(p)
+
+                            group['params'][pi] = new_p
+                        else:
+                            # --- Plain param: just move data ---
+                            p.data = p.data.cpu()
+                            if p.grad is not None:
+                                p.grad = p.grad.cpu()
+                    else:
+                        # --- Loading back to GPU ---
+                        key = (gi, pi)
+                        if hasattr(self, '_dtensor_originals') and key in self._dtensor_originals:
+                            orig_p = self._dtensor_originals[key]
+
+                            # Copy optimizer-updated values into original DTensor's local tensor
+                            orig_p.data.to_local().copy_(p.data.to(device))
+
+                            # Transfer optimizer state back to original DTensor param
+                            if p in self.optimus.optimizer.state:
+                                state = self.optimus.optimizer.state.pop(p)
+                                for k, v in state.items():
+                                    if isinstance(v, torch.Tensor):
+                                        state[k] = v.to(device)
+                                self.optimus.optimizer.state[orig_p] = state
+
+                            # Clear grad on original (will be recomputed in next fwd/bwd)
+                            orig_p.grad = None
+
+                            # Restore original DTensor param in optimizer
+                            group['params'][pi] = orig_p
+                        else:
+                            p.data = p.data.to(device)
+                            if p.grad is not None:
+                                p.grad = p.grad.to(device)
+        else:
+            # No optimizer yet: use submod.parameters()
+            for param in list(submod.parameters()):
+                if is_offloading:
+                    param.data = param.data.cpu()
+                    if param.grad is not None:
+                        param.grad = param.grad.cpu()
+                else:
+                    param.data = param.data.to(device)
+                    if param.grad is not None:
+                        param.grad = param.grad.to(device)
+
+        for buf in submod.buffers():
+            buf.data = buf.data.to(device)
 
     def offload_model(self):
         if self.optimus.swap_model_in_optstep == False:
             print(f"offload_model() should be used when swap_model_in_optstep == True")
             return
 
-        self.optimus.run_info.submod.to('cpu')
+        self._move_params('cpu')
 
         if self.optimus.display_mem == True:
             print(f" >>> >>> [rank:{self.optimus.tpl.rank}], offload model ...")
@@ -182,7 +279,7 @@ class Schedule:
             self.optimus.run_info.submod.load_state_dict(model_state['model_state_dict'])
             #print(f"[R] model state dict <-- DISK({disk_path_model})")
 
-        self.optimus.run_info.submod.to(self.optimus.run_info.device)
+        self._move_params(self.optimus.run_info.device)
 
         if self.optimus.display_mem == True:
             print(f" >>> >>> [rank:{self.optimus.tpl.rank}], load model ...")

--- a/opt_prime/opt_prime/schedule.py
+++ b/opt_prime/opt_prime/schedule.py
@@ -223,10 +223,27 @@ class Schedule:
         node = self.optimus.run_info.output_node
         #if self.optimus.model_type == self.optimus.model2type["hf"]:
         if self.optimus.model_type == self.optimus.model2type["hf"] or self.optimus.model_type == self.optimus.model2type["vt"]:
-            key_ = node.args[0]['logits']
+            if isinstance(node.args[0], dict) and 'logits' in node.args[0]:
+                key_ = node.args[0]['logits']
+            elif isinstance(node.args[0], (tuple, list)):
+                key_ = node.args[0][0]  # torch.export format: first element is logits
+            else:
+                key_ = node.args[0]
         elif self.optimus.model_type == self.optimus.model2type["sy"]:
             key_ = node.args[0]
+            # Export path may wrap output in a tuple: (submod_N,)
+            if isinstance(key_, (tuple, list)):
+                key_ = key_[0]
 
+        # One-time diagnostic: log output structure for debugging convergence
+        # Store flag on optimus (not self) since Schedule is recreated per run()
+        if not getattr(self.optimus, '_loss_diag_done', False):
+            self.optimus._loss_diag_done = True
+            print(f">> [LOSS-DIAG] output node.args[0] type={type(node.args[0]).__name__}, "
+                  f"key_={key_}, str(key_)='{str(key_)}'")
+            if str(key_) in self.optimus.run_info.getitem_dic:
+                gi = self.optimus.run_info.getitem_dic[str(key_)]
+                print(f">> [LOSS-DIAG] getitem_dic['{str(key_)}'] = {gi}")
 
         if str(key_) in self.optimus.run_info.getitem_dic:
             a_submod = self.optimus.run_info.getitem_dic[str(key_)][0]
@@ -283,9 +300,19 @@ class Schedule:
                 min_size = min(output1.size(0), target1.size(0))
                 output1 = output1[:min_size]
                 target1 = target1[:min_size]
+        # One-time shape diagnostic
+        if not getattr(self.optimus, '_loss_shape_diag_done', False):
+            self.optimus._loss_shape_diag_done = True
+            print(f">> [LOSS-DIAG] output1.shape={output1.shape}, target1.shape={target1.shape}, "
+                  f"output1.dtype={output1.dtype}")
+
         result = criterion(output1, target1)
 
-        #print(f" >>>> loss: {result}, result.shape:{result.shape}")
+        # Detect NaN/Inf in loss (indicates numerical instability)
+        if isinstance(result, torch.Tensor) and (torch.isnan(result).any() or torch.isinf(result).any()):
+            print(f">> [LOSS-DIAG] WARNING: NaN/Inf loss detected at mb_idx={mb_idx}! "
+                  f"loss={result.item()}, output1 has NaN={torch.isnan(output1).any().item()}, "
+                  f"output1 has Inf={torch.isinf(output1).any().item()}")
 
 
         self.optimus.run_info.grads[mb_idx][node.name] = (None,)

--- a/opt_prime/opt_prime/schedule_infer.py
+++ b/opt_prime/opt_prime/schedule_infer.py
@@ -79,6 +79,24 @@ class ScheduleInference:
                     self.optimus.run_info.env_recv_mark[0][node_name] = None
                     self.optimus.run_info.env_send_mark[0][node_name] = None
 
+        # Populate get_attr values from the top-level split graph.
+        # With the torch.export path, buffers used by inline ATen ops
+        # (e.g., inv_freq for RoPE) may remain as get_attr nodes in the
+        # split graph instead of being moved into submodules.
+        if hasattr(self.optimus, 'ir') and self.optimus.ir.model_ir:
+            split_gm = self.optimus.ir.model_ir[0]
+            for node in split_gm.graph.nodes:
+                if node.op == 'get_attr':
+                    try:
+                        attr = split_gm
+                        for atom in node.target.split('.'):
+                            attr = getattr(attr, atom)
+                        if isinstance(attr, torch.Tensor):
+                            self.optimus.run_info.env[0][node.name] = \
+                                attr.to(self.optimus.run_info.device)
+                    except Exception:
+                        pass  # Will be resolved lazily in extract_tensor_args
+
     def get_input(self, data: torch.Tensor) -> None:
         """
         Prepare input data for the first stage.
@@ -125,6 +143,79 @@ class ScheduleInference:
                                 )
                             self.optimus.run_info.env_recv_mark[0][node_name] = 1
 
+    def _resolve_buffer_or_param(self, node):
+        """Resolve a buffer/parameter node to its tensor value.
+
+        After split_module(), buffer references (e.g., inv_freq for RoPE)
+        may appear in the top-level split graph as placeholder or get_attr
+        nodes. split_module() may use naming conventions like 'b_' prefix
+        (buffer) or 'p_' (parameter) with dots replaced by underscores.
+        The actual buffer lives inside a submodule (e.g., submod_0.model...),
+        so we strip the submod_N prefix when matching.
+        """
+        # Build lookup cache on first call
+        if not hasattr(self, '_buf_param_cache'):
+            self._buf_param_cache = self._build_buf_param_cache()
+
+        name = node.name
+        val = self._buf_param_cache.get(name)
+        if val is not None:
+            return val.to(self.optimus.run_info.device)
+        return None
+
+    def _add_to_cache(self, cache, fqn, tensor):
+        """Add a tensor to the cache under multiple naming conventions."""
+        flat = fqn.replace('.', '_')
+        cache.setdefault(flat, tensor)
+        cache.setdefault(f"b_{flat}", tensor)
+        cache.setdefault(f"p_{flat}", tensor)
+        # Strip submod_N. prefix (buffer lives inside a partition)
+        parts = fqn.split('.')
+        if parts[0].startswith('submod_'):
+            short_fqn = '.'.join(parts[1:])
+            short_flat = short_fqn.replace('.', '_')
+            cache.setdefault(short_flat, tensor)
+            cache.setdefault(f"b_{short_flat}", tensor)
+            cache.setdefault(f"p_{short_flat}", tensor)
+
+    def _build_buf_param_cache(self):
+        """Build a name → tensor lookup for all buffers and parameters.
+
+        Searches both the pre-split GraphModule (self.ir.gm) and the
+        post-split module (model_ir[0]).  Also searches plain tensor
+        attributes since GraphModule._copy_attr stores copied buffers
+        as regular attributes (not registered buffers).
+        """
+        cache = {}
+        if not hasattr(self.optimus, 'ir'):
+            return cache
+
+        # Collect root modules to search
+        roots = []
+        if hasattr(self.optimus.ir, 'gm') and self.optimus.ir.gm is not None:
+            roots.append(self.optimus.ir.gm)
+        if self.optimus.ir.model_ir:
+            roots.append(self.optimus.ir.model_ir[0])
+
+        for root in roots:
+            # Registered buffers and parameters
+            for fqn, tensor in root.named_buffers():
+                self._add_to_cache(cache, fqn, tensor)
+            for fqn, tensor in root.named_parameters():
+                self._add_to_cache(cache, fqn, tensor)
+
+            # Also search plain tensor attributes in __dict__
+            # (GraphModule._copy_attr stores copied buffers as regular
+            #  attributes, not registered buffers, so named_buffers() misses them)
+            for mod_name, mod in root.named_modules():
+                for attr_name, attr_val in list(mod.__dict__.items()):
+                    if (isinstance(attr_val, torch.Tensor)
+                            and not isinstance(attr_val, nn.Parameter)):
+                        fqn = f"{mod_name}.{attr_name}" if mod_name else attr_name
+                        self._add_to_cache(cache, fqn, attr_val)
+
+        return cache
+
     def forward_core(self) -> Any:
         """
         Execute forward pass for this stage's submodule.
@@ -137,8 +228,20 @@ class ScheduleInference:
                 submod_name = self.optimus.run_info.getitem_dic[b.name][0]
                 idx = self.optimus.run_info.getitem_dic[b.name][1]
                 return self.optimus.run_info.env[0][submod_name][idx]
-            else:
+            elif b.name in self.optimus.run_info.env[0]:
                 return self.optimus.run_info.env[0][b.name]
+            else:
+                # Fallback: try to resolve as a buffer/parameter reference.
+                # This handles get_attr nodes and other node types that
+                # split_module() may create for cross-stage buffer access.
+                val = self._resolve_buffer_or_param(b)
+                if val is not None:
+                    self.optimus.run_info.env[0][b.name] = val  # cache
+                    return val
+                raise KeyError(
+                    f"Cannot resolve '{b.name}' "
+                    f"(op='{b.op}', target='{b.target}') in env"
+                )
 
         args = fx.graph.map_arg(self.optimus.run_info.node.args, extract_tensor_args)
         kwargs = fx.graph.map_arg(self.optimus.run_info.node.kwargs, extract_tensor_args)
@@ -192,13 +295,13 @@ class ScheduleInference:
         output_node = self.optimus.run_info.output_node
 
         # For HuggingFace models, extract logits
-        if self.optimus.model_type == self.optimus.model2type["hf"]:
-            key_ = output_node.args[0].get('logits')
-            if key_ is None:
-                key_ = output_node.args[0]
-        elif self.optimus.model_type == self.optimus.model2type["vt"]:
-            key_ = output_node.args[0].get('logits')
-            if key_ is None:
+        if self.optimus.model_type == self.optimus.model2type["hf"] or \
+                self.optimus.model_type == self.optimus.model2type["vt"]:
+            if isinstance(output_node.args[0], dict) and 'logits' in output_node.args[0]:
+                key_ = output_node.args[0]['logits']
+            elif isinstance(output_node.args[0], (tuple, list)):
+                key_ = output_node.args[0][0]  # torch.export format
+            else:
                 key_ = output_node.args[0]
         else:
             key_ = output_node.args[0]


### PR DESCRIPTION
dynamo capture option:
 - Provides an alternative to the existing torch.fx trace–based model capture using torch.export.export(). The model is captured at the bytecode level, decomposing all operations into ATen ops, then rebuilt at the module level so existing infrastructure (e.g., graph partitioning) can be reused.